### PR TITLE
Edit half of documentation subheadings

### DIFF
--- a/content/documentation/citation-bibliographies.md
+++ b/content/documentation/citation-bibliographies.md
@@ -6,7 +6,7 @@ type: essay
 
 In-text citations and bibliographies are all available in Quire. Designed to meet scholarly needs and multiple citation styles, they are easy to implement in your publications. While bibliographic references are formatted in YAML and stored in a YAML file (you can consult our [YAML syntax fundamentals](/guide/fundamentals/) for more information), citation and bibliography shortcodes are used to integrate the references in your publication.
 
-## Capturing Bibliographic Information in YAML
+## Capture Bibliographic Information in YAML
 
 Bibliographic references for your publication can be listed in a `references.yml` file in the `data` directory (along with the `publication.yml`, `figures.yml` and `objects.yml` files).
 
@@ -22,7 +22,7 @@ entries:
 
 These references can then be called individually from within text using the `q-cite` shortcode, or in their entirety as a generated bibliography using the `q-bibliography` shortcode. Both of which are detailed below.
 
-## Adding Inline Text Citations
+## Add Inline Text Citations
 
 The `q-cite` shortcode adds a linked Author Date citation reference to the text, and a hover pop-up with the full citation text. It also adds the citation to a list of all cited works on that page, which is output as a page-level bibliography, as explained [below](#displaying-a-bibliography).
 
@@ -53,7 +53,7 @@ The text element between the author date reference and the page can be changed w
 The `q-cite` shortcode can be used anywhere in your Markdown text, including within footnotes.
 
 
-## Displaying a Bibliography
+## Display a Bibliography
 
 Pages in your publication will automatically include a page-level bibliography listing all works that were cited on that page using the `q-cite` shortcode. However, to create a complete bibliography for your entire publication, from all the entries in the project's `references.yml` file, you can use the `q-bibliography` shortcode. The resulting bibliography will be output in the order in which it appears in the references file.
 
@@ -70,7 +70,7 @@ This shortcode accepts an optional `sort` value, which will sort the list by wha
 {{</* q-bibliography sort="short" */>}}
 ```
 
-You may in some cases find that the system’s default sort method is sub-optimal. In particular, the sort is case sensitive and will sort uppercase, before lower. So a reference for “e.e. cummings” would be listed after those for “Emily Dickinson”. In these cases a custom key like `"sort_as"` could be added to all entries in the `references.yml` file for fine-grained control.
+You may in some cases find that the system’s default sort method is suboptimal. In particular, the sort is case sensitive and will sort uppercase, before lower. So a reference for “e.e. cummings” would be listed after those for “Emily Dickinson”. In these cases a custom key like `"sort_as"` could be added to all entries in the `references.yml` file for fine-grained control.
 
 ```yaml
 entries:
@@ -83,6 +83,6 @@ entries:
 - If adding a custom sort key, it would need to be added to *all* entries, not just the one that need to be sorted differently than the default.
 {{< /q-class >}}
 
-### Displaying the Short Reference in Bibliographies
+### Display the Short Reference in Bibliographies
 
-Bibliographies displayed automatically at the bottom of pages, and those generated with the `q-bibliography` shortcode, can be just a list of the full version of the reference, or can include the short version as well. This is controlled globally (all bibliographies in the project have to be the same format) in the `config.yml` file with the `displayBiblioShort` property, can be set to `"true"` or `"false"`.
+Bibliographies displayed automatically at the bottom of pages, and those generated with the `q-bibliography` shortcode, can just be a list of the full version of the reference, or can include the short version as well. This is controlled globally (all bibliographies in the project have to be the same format) in the `config.yml` file with the `displayBiblioShort` property, can be set to `"true"` or `"false"`.

--- a/content/documentation/collection-catalogues.md
+++ b/content/documentation/collection-catalogues.md
@@ -4,11 +4,11 @@ weight: 5100
 type: essay
 ---
 
-Along with monographs, edited volumes and serial publications, Quire is also designed with the publication of museum collection catalogues in mind and has a specific page `type` for them (See all page types in the [*Defining Page Types* section](/guide/pages#defining-page-types) of the *Pages and Plain Text* page of this guide). Collection catalogues typically feature a page for each object, featuring images of the object, information about it, and an essay or entry text. To publish a catalogue with Quire, you’ll capture each object data, create the object pages, and then optionally, display a list of the objects included in your publication. Essays in object pages work in the same way as any other pages and you can visit our [*Markdown fundamentals*](/guide/fundamentals/) page for reference.
+Along with monographs, edited volumes and serial publications, Quire is also designed with the publication of museum collection catalogues in mind and has a specific page `type` for them (See all page types in the [*Defining Page Types* section](/guide/pages#defining-page-types) of the *Pages and Plain Text* page of this guide). Collection catalogues typically feature a page for each object, featuring images of the object, information about it, and an essay or entry text. To publish a catalogue with Quire, you’ll capture each object data, create the object pages, and then, optionally, display a list of the objects included in your publication. Essays in object pages work in the same way as any other pages and you can visit our [*Markdown fundamentals*](/guide/fundamentals/) page for reference.
 
-## Capturing Object Data
+## Capture Object Data
 
-Much like `figures.yml` or `references.yml`, all catalogue object metadata should be captured in a single `objects.yml` file in the `data` directory of your project and then called as needed in different pages of your publication. Here is a brief sample:
+Much like `figures.yml` or `references.yml`, all catalogue object metadata should be captured in a single `objects.yml` file in the `data` directory of your project and then labeled as needed in different pages of your publication. Here is a brief sample:
 
 ```yaml
 object_display_order:
@@ -61,7 +61,7 @@ Here are the only defined object attributes, you can include any others you like
 | `date_start`, `date_end` | Reserved for future use in Quire. |
 | `dimension_width`, `dimension_height`, `dimension_depth` | Reserved for future use in Quire. |
 
-## Creating Object Pages
+## Create Object Pages
 
 Like all other pages in your publication, object pages are generated from the Markdown files in your `content` directory. To create an object entry page, give the page a `type: entry` in the page YAML block, and list one or more objects by `id` corresponding to those in your `objects.yml` file.
 
@@ -81,9 +81,9 @@ If you add multiple figures of the object, these are displayed in a rotating car
 - In the table of object information, the items displayed and their titles are determined by the `object_display_order` attribute in the `objects.yml` file, as detailed in the section above. If the object information included a `link`, a “View in Collection” button is generated. The text of this button can be customized with the `objectLinkText` attribute in the project’s `config.yml` file.
 {{< /q-class >}}
 
-## Generating Object Lists/Grids
+## Generate Object Lists/Grids
 
-In a collection catalogue, there will typically be a visual table of contents for just the catalogue entries. To create a page with a list or visual grid of all the object entries, the entries themselves need to be grouped in their own section. In Quire, this means putting them in a sub-directory within the main `content` directory (Read more about it in the [*Pages and Plain Text*](/guide/pages/) page of this guide).
+In a collection catalogue, there will typically be a visual table of contents for just the catalogue entries. To create a page with a list or visual grid of all the object entries, the entries themselves need to be grouped in their own section. In Quire, this means putting them in a subdirectory within the main `content` directory (Read more about it in the [*Pages and Plain Text*](/guide/pages/) page of this guide).
 
 In this example, inside the `content` directory, we have a folder called `catalogue` and inside that, three numbered entries and an overview page:
 

--- a/content/documentation/contributors.md
+++ b/content/documentation/contributors.md
@@ -4,9 +4,9 @@ weight: 5300
 type: essay
 ---
 
-Quire is designed to credit and add contributors to publications in a flexible way. Contributors data is stored in the `publication.yml` file of your project or in the YAML block of individual pages. The `q-contributor` shortcode offers multiple options to display contributors data in your publication.
+Quire is designed to credit and add contributors to publications in a flexible way. Contributors' data is stored in the `publication.yml` file of your project or in the YAML block of individual pages. The `q-contributor` shortcode offers multiple options to display contributors data in your publication.
 
-## Adding Contributors to Your Project
+## Add Contributors to Your Project
 
 Contributors can be listed under `contributor` in your publication.yml file, or for contributors specific to a page in your project, in the YAML block at the top of that page.
 
@@ -26,11 +26,11 @@ At a minimum, each contributor must have a `first_name` and `last_name`, or just
   bio:
 ```
 
-## Displaying Contributors on Your Cover
+## Display Contributors on Your Cover
 
 Any contributor listed in your publication.yml file that has a `type: primary` will be considered a main author for your project and will be listed on the cover page, in the site menu, and in the metadata included in the project code. For publications with more than one author, names will be listed in the order they appear in the publication.yml file.
 
-Sometimes, rather than a plain list, you may want your contributors listed in a particular way. Such as, “Edited by Author Name and Author Name”. In these cases, you can add you custom text in the publication.yml file under `contributor_as_it_appears` which can also take Markdown and HTML tags as needed.
+Sometimes, rather than a plain list, you may want your contributors listed in a particular way. Such as, “Edited by Author Name and Author Name”. In these cases, you can add your custom text in the publication.yml file under `contributor_as_it_appears` which can also take Markdown and HTML tags as needed.
 
 ```yaml
 contributor_as_it_appears: as told by Beyoncé, Kelly Rowland,
@@ -42,7 +42,7 @@ contributor_as_it_appears: as told by Beyoncé, Kelly Rowland,
 
 While the `contributor_as_it_appears` value will override any contributor information otherwise listed, it is still recommended that you list the individual authors under the `contributor` area in your YAML, as this will be used as metadata for your book and will aid search engines and social media sites in discovering and listing your site.
 
-## Displaying Contributors on Individual Pages
+## Display Contributors on Individual Pages
 
 Individual pages in your publication can have specific authors. Add them to the page YAML either with their names and other information, or by using an `id` that references a corresponding listing in your publication.yml file.
 
@@ -105,13 +105,13 @@ The `"range"` value determines which contributors will be included in the list. 
 |`page` | Only the contributors listed for the page the shortcode appears on. |
 | `all` | All contributors listed in the publication, whether listed on individual pages or in the publication.yml file. |
 
-You can also use any contributor `type` you define. So if you give a contributor a `type: primary` (such as for your main publication authors as discussed in the [“Displaying Contributors on Your Cover”](#displaying-contributors-on-your-cover)) than a shortcode using `range="primary"` will list any of your project’s primary contributors.
+You can also use any contributor `type` you define. So if you give a contributor a `type: primary` (such as for your main publication authors, as discussed in the [“Displaying Contributors on Your Cover”](#displaying-contributors-on-your-cover)), then a shortcode using `range="primary"` will list any of your project’s primary contributors.
 
 The `"format"` value determines what information will be listed for each contributor in the `"range"`, and how it will be formatted. Possible `"format"` values are:
 
 | Value | Description |
 | --- | --- |
-|`initials` | Looks for the capital letters in a contributor first and last name and concatenates them together. Jane Pauley, becomes J.P.; Ralph Waldo Emerson becomes R.W.E. |
+|`initials` | Looks for the capital letters in a contributor first and last name and combines them together. Jane Pauley becomes J.P.; Ralph Waldo Emerson becomes R.W.E. |
 | `name` | Just the name. |
 | `name-title` | The name and, when available, the title and affiliation; on a single line |
 | `name-title-block` | The name and, when available, the title and affiliation; broken onto separate lines. |
@@ -135,19 +135,19 @@ The `"align"` value will align the text. If no value is given, text alignment wi
 
 See the [`q-contributor` shortcode reference](/api-docs/shortcodes#q-contributor) for details on each of the standard contributor attributes.
 
-#### Sorting Contributor Lists
+#### Sort Contributor Lists
 
 Using the shortcode, contributors will be listed alphabetically. Either by `last_name` `first_name` if given, or `full_name`. You can specify a `file_as` value for contributors to override the default sorting.
 
-If you wanted, for example, a list of essay contributors ordered in the way they are ordered in the page YAML block, you could assign a numeric `file_as` value to each (1, 2, 3 etc.). Note though that this `file_as` override will cary over to other uses of the shortcode. For example, a complete list of contributors at the end of a volume of collected papers.
+If you wanted, for example, a list of essay contributors ordered in the way they are ordered in the page YAML block, you could assign a numeric `file_as` value to each (1, 2, 3 etc.). Note though that this `file_as` override will carry over to other uses of the shortcode. For example, a complete list of contributors at the end of a volume of collected papers.
 
 {{< q-class "box warning" >}}
 
-- Contributors with the same exact name will override each other and only one will appear, but using a `file_as` value would fix this. For example, if there are two Jane Smiths, assigning a `file_as` value of "Smith, Jane 1" to one and "Smith, Jane 2" will sort them in that order, but their names would still be listed as Jane Smith.
+- Contributors with the same name will override each other and only one will appear, but using a `file_as` value would fix this. For example, if there are two Jane Smiths, assigning a `file_as` value of "Smith, Jane 1" to one and "Smith, Jane 2" will sort them in that order, but their names would still be listed as Jane Smith.
 
 {{< /q-class >}}
 
-## Including Contributors for Search Engines
+## Include Contributors for Search Engines
 
 Contributor information is also embedded in Quire projects in a way that is optimized for search engine discovery. Here are a few tips to take advantage of this feature:
 

--- a/content/documentation/figure-images.md
+++ b/content/documentation/figure-images.md
@@ -7,7 +7,7 @@ type: essay
 Quire books are visual and the framework is built to support the use of images for scholarly purposes. In this page, we explain where images are placed in the project and how you can manage them. We recommend using the `figures.yml` file to manage all the information about your images, and then inserting them into your Markdown documents where they are needed with the [`q-figure` shortcode](#inserting-figure-images-with-the-q-figure-shortcode).
 
 
-## Including Figure Image Files in Your Publication
+## Include Figure Image Files in Your Publication
 
 Figure image files should be placed in the `static/img/` directory. It is defined in your project `config.yml` file with the parameter `imageDir: "/img/"` and the directory can be changed if needed.
 
@@ -20,7 +20,7 @@ Quire does not require a specific image file format or size, but we have some re
 - Watch out for file sizes, especially on animated gifs which can get to be multiple megabytes quite quickly. Use {{< q-glossary "Image Optimization" >}} software when possible, and consider the total number of images on a given page when choosing sizes.
 
 
-## Creating a `figures.yml` File for Figure Image Metadata
+## Create a `figures.yml` File for Figure Image Metadata
 
 For most publications, or at least, those with more than just a handful of images, figures and all their associated attributes can be listed in the `figures.yml` file which should be placed in your `data` folder. These then can be called from wherever you need them in your project with a shortcode. See the API-DOCs section for [complete details on possible figure attributes](/api-docs/yaml/#figure), but below there is a very simple example with `id` and `src` (required attributes) and `alt` (recommended attribute).
 
@@ -41,7 +41,7 @@ Also available are the attributes `caption`, `credit`, `media_id`, `media_type`,
 
 {{< /q-class >}}
 
-## Inserting Figure Images with the `q-figure` Shortcode
+## Insert Figure Images with `q-figure` Shortcode
 
 Assuming each YAML figure entry in the `figures.yml` file includes a unique `id` (with a value in quotes: "1.1" not 1.1), you can insert a figure in your publication with only the `id` attribute in the shortcode, and all of the other attributes defined in the YAML for that figure will be automatically included.
 
@@ -65,7 +65,7 @@ If you include an attribute in the shortcode that is also in the `figures.yml` f
 
 {{< /q-class >}}
 
-## Labeling Figure Images
+## Label Figure Images
 
 By default, all figure images are labeled automatically, either at the start of the caption or just under the image itself in the case of a figure group with a single, group caption [(see below)](#creating-and-styling-figure-groups-with-the-q-figure-group-shortcode). You can turn off this behavior in the `config.yml` file by switching the value `figureLabels: true` to `figureLabels: false`.
 
@@ -76,7 +76,7 @@ To customize the label text on a figure-by-figure basis, use the `label_text` at
 To remove a label from a specific figure or a group of figures, add `label="false"` to the shortcode. Or, in reverse, if you already have `figureLabels: false` set in your `config.yml` file, use `label="true"` in the shortcode to show a label for that figure.
 
 
-## Styling Figure Images
+## Style Figure Images
 
 Depending on your {{< q-glossary "theme" >}}, by default, figures will appear at about the width of the full-column of text. Modifier classes can be added to a shortcode to style the way the figures appear. Available classes are `is-pulled-left` and `is-pulled-right`. Classes are added just like other attributes in the shortcode.
 
@@ -93,7 +93,7 @@ Depending on your {{< q-glossary "theme" >}}, by default, figures will appear at
 
 {{< /q-class >}}
 
-## Creating and Styling Figure Groups with the `q-figure-group` Shortcode
+## Create and Style Figure Groups with `q-figure-group` Shortcode
 
 If your project uses a `figures.yml` file, you can also create a group of figures by using the `q-figure-group` shortcode and simply including multiple, comma-separated values in the `id` field.
 
@@ -126,7 +126,7 @@ In addition to all the attributes available to the `q-figure` shortcode, the `q-
 
 {{< /q-class >}}
 
-## Adding Video Figures
+## Add Video Figures
 
 Videos can be embedded in your publication the same way as other figure images, using either of the two figure shortcodes. The difference is in the `figures.yml` file where you’ll need to include a `media_id` and a `media_type` attribute for any video, along with an optional `aspect_ratio` attribute.
 
@@ -153,7 +153,7 @@ Quire supports video embeds from either YouTube (`media_type: youtube`) or Vimeo
 
 {{< /q-class >}}
 
-## Adding Basic Figures
+## Add Basic Figures
 
 If you are not using a `figures.yml` file, figures—including still images and animated gifs but not video—can be inserted in any Markdown document in your publication with the `q-figure` shortcode, where `src` is the name of your file as it appears in the `static/img/` directory of your project.
 

--- a/content/documentation/figure-images.md
+++ b/content/documentation/figure-images.md
@@ -20,7 +20,7 @@ Quire does not require a specific image file format or size, but we have some re
 - Watch out for file sizes, especially on animated gifs which can get to be multiple megabytes quite quickly. Use {{< q-glossary "Image Optimization" >}} software when possible, and consider the total number of images on a given page when choosing sizes.
 
 
-## Create a `figures.yml` File for Figure Image Metadata
+## Create a figures.yml File for Figure Image Metadata
 
 For most publications, or at least, those with more than just a handful of images, figures and all their associated attributes can be listed in the `figures.yml` file which should be placed in your `data` folder. These then can be called from wherever you need them in your project with a shortcode. See the API-DOCs section for [complete details on possible figure attributes](/api-docs/yaml/#figure), but below there is a very simple example with `id` and `src` (required attributes) and `alt` (recommended attribute).
 
@@ -41,7 +41,7 @@ Also available are the attributes `caption`, `credit`, `media_id`, `media_type`,
 
 {{< /q-class >}}
 
-## Insert Figure Images with `q-figure` Shortcode
+## Insert Figure Images with q-figure Shortcode
 
 Assuming each YAML figure entry in the `figures.yml` file includes a unique `id` (with a value in quotes: "1.1" not 1.1), you can insert a figure in your publication with only the `id` attribute in the shortcode, and all of the other attributes defined in the YAML for that figure will be automatically included.
 
@@ -93,7 +93,7 @@ Depending on your {{< q-glossary "theme" >}}, by default, figures will appear at
 
 {{< /q-class >}}
 
-## Create and Style Figure Groups with `q-figure-group` Shortcode
+## Create and Style Figure Groups with q-figure-group Shortcode
 
 If your project uses a `figures.yml` file, you can also create a group of figures by using the `q-figure-group` shortcode and simply including multiple, comma-separated values in the `id` field.
 

--- a/content/documentation/fonts-customization.md
+++ b/content/documentation/fonts-customization.md
@@ -1,12 +1,12 @@
 ---
-title: Fonts Customization
+title: Font Customization
 weight: 5500
 type: essay
 ---
 
 Typography is an important element of style in your Quire publication. Quire allows different levels of font customization, from using the already embedded open license fonts in the `quire-starter-theme` to adding new external fonts.
 
-## Customizing Fonts
+## Customize Fonts
 
 The `quire-starter-theme` includes three embedded, open license fonts: ["Merriweather"](https://fonts.google.com/specimen/Merriweather), ["Lato"](https://fonts.google.com/specimen/Lato), and ["Aleo"](http://www.fontfabric.com/aleo-free-font/). You can adjust which ones are used where in the "variables" file of your {{< q-glossary "theme" >}}, `source/css/variables.scss`:
 
@@ -26,7 +26,7 @@ The `$serif`, `$sans-serif` and  `$slab-serif` variables tell your publication w
 
 The variables `$family-primary` and `$family-secondary` tell your publication where to use the fonts you specify with the above variables. If the `$family-primary` font of your publication is `$serif`, "Merriweather" (and its fallback options) will be used in the body text of the publication pages.
 
-## Adding a New Font
+## Add a New Font
 
 {{< q-class "box warning" >}}
 
@@ -38,7 +38,7 @@ For open license fonts, [Google Fonts](https://fonts.google.com/) is a great sou
 
 The steps to adding new fonts to your publication are:
 
-### 1. Preparing Your Font Files and Adding Them to Your Project
+### 1. Prepare Your Font Files and Add Them to Your Project
 
 It’s recommended to include your font files in multiple file formats in order to increase browser compatibility. Ideally, you will have each of your fonts in the following formats: `.eot`, `.woff2`, `.woff`, and `.ttf`. If this is not the case, you can use a free webfont generator like the one from Font Squirrel to produce these various formats from a single source.
 
@@ -68,7 +68,7 @@ You will continue to have the fonts available in your local copy of your project
 
 When you ultimately host the final site on a web server, the fonts will be included in the built files and will need to be included in the package on the web server. Files hosted this way are not readibly accessible to non-technical users, but are still public. For another layer of protection, if it’s of a concern, font files could be assigned more generic names (ie., `f1-bld.ttf` instead of `cooper-hewitt-bold.ttf`). For complete protection of licensed/proprietary font files, other solutions should be sought.
 
-### 2. Adding Font Information to Your Stylesheets
+### 2. Add Font Information to Your Stylesheets
 
 Open the file `source/css/fonts.scss`. Each font in your font folder should have its own `@font-face` entry as the examples in this file demonstrate.
 
@@ -105,7 +105,7 @@ The individual weights and styles are instead specified with the `font-weight` a
 
 - The `font-style` will be either `normal` or `italic`.
 
-### 3. Using Your New Font
+### 3. Use Your New Font
 
 With the font files included in the `source/fonts` folder, and all the matching `@font-face` entries saved to the `source/css/fonts.scss` file, you can now use your font anywhere in your site CSS with `font-family`.
 
@@ -115,7 +115,7 @@ h1 {
 }
 ```
 
-Typically, you’ll want to change fonts across the project. For instance making all the main body copy a new font, or all the headings. This can be done in the `source/css/variables.scss` file that we describe in the [Customizing fonts section](#customizing-fonts):
+Typically, you’ll want to change fonts across the project. For instance making all the main body copy a new font, or all the headings. This can be done in the `source/css/variables.scss` file that we describe in the [Customize fonts section](#customizing-fonts):
 
 To replace all `$sans-serif` uses with a new font:
 
@@ -129,4 +129,4 @@ Or to leave the existing `$sans-serif` and just make all the primary font be our
 $family-primary: "Cooper Hewitt", Helvetica, sans-serif;
 ```
 
-The rules about fallback fonts described in the [Customizing fonts section](#customizing-fonts) above also apply to the new fonts.
+The rules about fallback fonts described in the [Customize fonts section](#customizing-fonts) above also apply to the new fonts.

--- a/content/documentation/fundamentals.md
+++ b/content/documentation/fundamentals.md
@@ -186,7 +186,7 @@ Dashes and numbers create lists. Indenting creates nested lists.
 
 ### Footnotes
 
-Precede footnote numbers with a up-arrow accent (`^`) and then surround it in square brackets. Footnote number one would be `[^1]`, number two would be `[^2]`, and so on.
+Precede footnote numbers with an up-arrow accent (`^`) and then surround it in square brackets. Footnote number one would be `[^1]`, number two would be `[^2]`, and so on.
 
 At the end of the page, usually under a “Notes” heading, add the corresponding note with the same marker followed by a colon and the note text.
 

--- a/content/documentation/getting-started.md
+++ b/content/documentation/getting-started.md
@@ -1,10 +1,10 @@
 ---
-title: Getting Started
+title: Get Started
 type: essay
 weight: 4100
 ---
 
-## Starting a New Project
+## Start a New Project
 
 To create a new project, open your {{< q-glossary "command-line shell" >}} and copy and paste the text below, replacing `project-name` with what you would like your project folder to be called. (Don’t use spaces or special characters in your project name, and lowercase is recommended.)
 
@@ -16,7 +16,7 @@ The process may take a minute as Quire installs the starter kit, configures the 
 
 The project is ready when you see the message, “Theme and dependencies successfully installed.”
 
-## Copying an Existing Project
+## Copy an Existing Project
 
 In addition to starting a Quire project from scratch as described in the previous section, you can also copy and work on a pre-existing Quire project. You would do this if you were on a team working on a publication together and are sharing the files via GitHub or another service, or you wanted to use a previous Quire project as a template for a new one.
 
@@ -106,11 +106,11 @@ Where the built pages of the Quire website will be. This folder and its contents
 
 The `themes` directory contains one or more {{< q-glossary "themes" >}} that define the structure and style of the Quire publication. When using the `quire new` command-in the Quire CLI, the default theme is `quire-starter-theme`. Read more in [*Customizing Styles*](/guide/styles-customization/).
 
-## Creating a Publication Outline
+## Create a Publication Outline
 
 It is a good idea to start any project by creating a basic outline of your publication. The way you organize the Markdown files in the `content` directory of your project will define the structure of your publication and how the *Table of Contents* is organized.
 
-Here’s an outline showing the ordering, organization, and file naming for a sample publication:
+Here’s an outline showing the order, organization, and file names for a sample publication:
 
 ```md
 📄 cover.md
@@ -147,11 +147,11 @@ There are some other important rules and tips to keep in mind:
 
 3. **Don't use `index.md` or `_index.md` files.** Though common for users with previous static-site or web development experience, you should not use `index.md` or `_index.md` files in your Quire project. Because of the way {{< q-glossary "Hugo" >}} is modeled, these work against the linear ordering of the publication and break the *Next* and *Previous* page navigation in Quire.
 
-## Prepping Images and Text
+## Prepare Images and Text
 
 TK
 
-## Previewing and Editing a Project
+## Preview and Edit a Project
 
 Quire lets you preview the current version of your site in a web browser, and will update the preview as you edit the files.
 

--- a/content/documentation/install-uninstall.md
+++ b/content/documentation/install-uninstall.md
@@ -250,7 +250,7 @@ If version number is returned, quire-cli was installed correctly. You can now le
 cd ~
 ```
 
-## Updating the Quire CLI
+## Update the Quire CLI
 
 As we develop, you may also want/need to update your Quire CLI. The CLI is pegged to a particular version of the Quire Starter Theme (at least for now), so if you’re using an older CLI, any new projects you start will have the corresponding older version of the theme.
 
@@ -291,7 +291,7 @@ You now have the latest Quire CLI and any new projects you start will also have 
 
 You may in some cases see errors or issues when running Quire commands with a newer version of the CLI in older projects. These can be fixed manually, or, you can also re-install [your original version of the CLI](https://github.com/gettypubs/quire-cli/releases) to run those older projects if necessary.
 
-## Updating the Theme
+## Update the Theme
 
 To update the version of a theme you have:
 
@@ -304,11 +304,11 @@ To update the version of a theme you have:
 - Be sure to save any [customizations you’ve made](/guide/styles-customization) inside your theme. (Typically style changes to the `variables.scss` file.) You’ll have to copy these over into the new theme manually once it is installed.
 {{< /q-class >}}
 
-## Installing a New Theme
+## Install a New Theme
 
 TK
 
-## Uninstalling Quire
+## Uninstall Quire
 
 To uninstall Quire:
 
@@ -328,7 +328,7 @@ To uninstall Quire:
 
 **Downloading the Quire CLI to your computer from GitHub through the Terminal**
 
-If you have {{< q-glossary "two-factor authentication" >}} set-up, you may need to create a personal access token in GitHub to get Quire CLI to download properly.
+If you have {{< q-glossary "two-factor authentication" >}} set up, you may need to create a personal access token in GitHub to get Quire CLI to download properly.
 
 Follow these steps:
 
@@ -366,7 +366,7 @@ You will be prompted to enter a password and may receive the following error, *O
 
 Please note, on some computers you may not need to run this command.
 
-Try continuing with the installation process to see if everything is running smoothly:
+Try to continue with the installation process to see if everything is running smoothly:
 
   ```text
   cd quire-cli
@@ -375,7 +375,7 @@ Try continuing with the installation process to see if everything is running smo
 
 If this works, then you can ignore the *sudo chown* command.
 
-When when you have finished these steps, type the following command to confirm proper installation:
+When you have finished these steps, type the following command to confirm proper installation:
 
   ```text
   quire --version

--- a/content/documentation/metadata-configuration.md
+++ b/content/documentation/metadata-configuration.md
@@ -8,7 +8,7 @@ Quire uses two {{< q-glossary "YAML" >}} files as sources of the metadata and to
 
 You can read more about [*YAML syntax basics*](/resources/cheatsheet/) and check out a sample of the [*`publication.yml` file*](/resources/sample-publication-file/) in other chapters of this guide.
 
-## Adjusting the Default Publication Settings in the `config.yml` File
+## Adjust the Default Publication Settings in config.yml File
 
 The `config.yml` file is a standard and required file for {{< q-glossary "Hugo" >}}, and also for Quire. In Quire, it is used expressly for configuring how Hugo operates, and for defining a number of key values used in Quire {{< q-glossary "templates" >}}. Users who have worked on other non-Quire Hugo projects will note that they typically use the `config.yml` file to also store publication metadata. Given the potentially large scope of this kind of metadata in formal digital publications, Quire instead uses the `publication.yml` file inside the `data` directory for that purpose [(see below)](#adding-and-editing-important-metadata-in-the-publication-yml-file).
 
@@ -20,7 +20,7 @@ The properties in the `config.yml` file are individually documented in the [*API
 
 - The `params` section includes a number of values specific to various Quire layout {{< q-glossary "templates" >}} and {{< q-glossary "shortcodes" >}}. All are provided with default values, and should be changed with care. In cases where a value should be deleted entirely, it is usually best to leave it as empty double quotes (`""`) rather than completely deleting it.
 
-## Adding and Editing Important Metadata in the `publication.yml` File
+## Add and Edit Important Metadata in publication.yml File
 
 The `publication.yml` file in the `/data` directory is *the* source of metadata for your publication. While the only value that is truly required is the one for the property `title`, it is a good idea to fill out the `publication.yml` file as completely as possible. Many of the properties are used in the metadata, which is automatically included in the underlying code of every page of the online edition of your publication to support {{< q-glossary "Search Engine Optimization (SEO)" >}} and general discovery.
 

--- a/content/documentation/netlify.md
+++ b/content/documentation/netlify.md
@@ -80,7 +80,7 @@ command = "npm run build:stage"
 HUGO_VERSION = "0.55.5"
 ```
 
-### Altering or adding another command
+### Alter or add another command
 
 When we run the build process on Netlify we may want to add flags to our Hugo command to make Hugo behave differntly either on a specific branch or in the preview deploy.
 Let say for example we want to add the flag to build drafts for a branch and not for production.

--- a/content/documentation/page-content.md
+++ b/content/documentation/page-content.md
@@ -4,7 +4,7 @@ type: essay
 weight: 4700
 ---
 
-## Formatting Text Content with Markdown
+## Format Text Content with Markdown
 
 The main content of your page appears after the YAML block at the top ([*Page Types & Structure*](/guide/pages/)), and will be formatted in Markdown. Markdown is a very simple, plain text markup language that uses a few text rules to structure content for easy conversion into HTML. For example, a hash or pound sign at the beginning of a line makes a heading, and one set of asterisks wrapping around the text turns it *italic*.
 
@@ -17,7 +17,7 @@ type: essay
 weight: 206
 ---
 
-## Formatting Text Content with Markdown
+## Format Text Content with Markdown
 
 The main content of your page appears after the YAML block at
 the top ([*Page Types & Structure*](/guide/pages/)), and will be
@@ -30,7 +30,7 @@ wrapping text turns it *italic*.
 
 You can read all about Markdown syntax and how it is used in Quire in the [*Fundamentals: YAML & Markdown*](/guide/fundamentals/) chapter of this guide.
 
-## Using Shortcodes to Add Features
+## Use Shortcodes to Add Features
 
 Quire adds a number of specialty shortcodes which extend the functionality and possibilities of plain Markdown. While {{< q-glossary "Hugo" >}} has a number of built-in shortcodes, which can also work in Quire, Quire-specific shortcodes always start with a `q`.
 
@@ -65,7 +65,7 @@ The following shortcodes are currently available in Quire. You’ll find more ab
 - [`q-figure`](/guide/figure-images/): Inserts a formatted figure image (including audio and video) and caption using data from the project’s `figures.yml` file, or from values supplied directly in the shortcode.
 - [`q-figure-group`](/guide/figure-images/): Like `q-figure`, but with handling for multiple images at once.
 
-## Applying Types of Linking
+## Apply Different Types of Links
 
 As seen in the example above, a link is created by combining the text of the link in brackets with the url of the link in parentheses: `[Link text](Link URL)` There are several types of linking that can be applied to text on your page. Stylization such as bolding, italics, underlining, and more can also be applied to linked text.
 
@@ -94,7 +94,7 @@ More info in our [about](/about/) page.
 
 There are several types of linking between features, text, or objects on a single page that can be included through the following Markdown formatting:
 
-#### Linking to Figures
+#### Links to Figures
 
 This linking can be applied to a piece of text that when clicked upon will take a user to the location of the corresponding figure on the page. Figure IDs can be found on the `figures.yml` page as explained in the [*Figure Images*](/guide/figure-images/) chapter of this guide. They are proceeded by the # symbol when used as a link address.
 
@@ -103,7 +103,7 @@ This linking can be applied to a piece of text that when clicked upon will take 
 [fig. 1](#1.1)
 ```
 
-#### Linking to Other Kinds of Page Elements
+#### Links to Other Kinds of Page Elements
 
 An ID and the # symbol is also used for other kinds of elements on the same page. The IDs for these elements can be found using the following method:
 
@@ -118,7 +118,7 @@ An ID and the # symbol is also used for other kinds of elements on the same page
     See [heading 1](#heading-1).
     ```
 
-#### Linking to Elements on a Separate Page
+#### Links to Elements on a Separate Page
 
 Following the formula for internal links between pages, you can also specify an element on a separate page as a link destination by adding the # symbol and the element’s ID on to the end of a page link.
 

--- a/content/documentation/pages.md
+++ b/content/documentation/pages.md
@@ -36,7 +36,7 @@ slug:
 
 For more details on this full list of possible attributes that Quire can use in page YAML, see the [Page YAML](/api-docs/yaml/#page) section of the Quire API docs.
 
-## Defining Page Types
+## Define Page Types
 
 ```yaml
 type:
@@ -76,7 +76,7 @@ type: entry
 class: landscape (default) | side-by-side
 ```
 
-## Putting Pages in the Right Order
+## Organize Pages in the Right Order
 
 ```yaml
 weight:
@@ -106,7 +106,7 @@ Numbering should be unique, and sequential whole numbers, but it can skip number
 - Add `class: page-one` to the page/chapter where you want page 1 to start for the PDF/Print output. This is often an Introduction or first essay rather than the cover, table of contents, or other frontmatter.
 {{< /q-class >}}
 
-## Creating Section Landing Pages
+## Create Section Landing Pages
 
 A Quire publication can have sub-sections, created by nesting a group of one or more pages inside a sub-directory within the main `content` directory. It is recommended (though not required) to designate one of the pages in each sub-directory section to be the section landing page. To do so, add `slug: .` to the page YAML block. The `slug` attribute overrides the default name to be used in the URL for the page, and the period `.` refers it back to the sub-directory name. So, if in your site `mypublication.com` you have sub-directory called `part-one` and in that a landing page called `landing-page.md`, instead of the URL being `mypublication.com/part-one/landing-page/`, it would be `mypublication.com/part-one/`. Here’s the YAML:
 
@@ -121,7 +121,7 @@ The `title` of your defined landing page is what will be used in the header of t
 
 However, the filename of the sub-directory itself is also used in your publication; for the online navigation bar, and in the running page footers of the PDF version. In these two places, Quire takes the sub-directory filename and humanizes it, which means to change hyphens into spaces and capitalize with title case. So, the sub-directory `part-one` becomes “Part One”, or `sculpture-of-the-renaissance` becomes “Sculpture of the Renaissance.”
 
-## Hiding/Showing Pages
+## Hide/Show Pages
 
 By default, every page you create will be included in all formats of your publication (online, PDF/print, and e-book). Every page will also automatically be listed in the publication’s menu and contents pages. However, this can be overridden by setting any of the following Page YAML attributes to `false`.
 

--- a/content/documentation/quire-cli.md
+++ b/content/documentation/quire-cli.md
@@ -4,13 +4,13 @@ weight: 4200
 type: essay
 ---
 
-The [Quire CLI](https://github.com/gettypubs/quire-cli), or command-line interface, is the control for creating, previewing and outputting Quire projects. Quire CLI is typically run from Terminal on a Mac, and Git Bash (or its equivalent) on a PC. The following commands are available.
+The [Quire CLI](https://github.com/gettypubs/quire-cli), or command-line interface, is the control for creating, previewing and outputting Quire projects. Quire CLI is typically run from Terminal on a Mac and Git Bash (or its equivalent) on a PC. The following commands are available.
 
 {{< q-class "box tip" >}}
 - Run `quire --help` in your command-line shell for a full list of the Quire commands and options defined below.
 {{< /q-class >}}
 
-## Starting and Previewing Projects
+## Start and Preview Projects
 
 `quire new project-name`
 : Create a new Quire project named `project-name` in the current directory. The name can be anything, but shouldn’t contain spaces or special characters.
@@ -25,7 +25,7 @@ The [Quire CLI](https://github.com/gettypubs/quire-cli), or command-line interfa
 : Stop the preview from running. This can also be done by typing Control-C.
 
 
-## Outputting Files
+## Output Files
 
 `quire site`
 : Build the final web files for your publication into its `site` directory. These include all the pages, images, and styles necessary for your project, and can be hosted on any web server.
@@ -62,12 +62,12 @@ Outputs as: `static/ebooks/photography.epub`.
 Also for the PDF, EPUB, and MOBI commands, developers may  use the `--env` option to specify and environmental variable.
 
 
-## Customizing File Templates
+## Customize File Templates
 
 `quire template epub`
 : Download the built-in template for customization of the cover and title pages of the EPUB and MOBI files Quire outputs. `epub/template.xhtml` All other template customization (for the website and pdf/print versions) is done in the `theme` directory.
 
-## Getting Help
+## Get Help
 
 `quire -V` `quire --version`
 : Output the version number.

--- a/content/documentation/styles-customization.md
+++ b/content/documentation/styles-customization.md
@@ -1,5 +1,5 @@
 ---
-title: Styles Customization
+title: Style Customization
 weight: 5400
 type: essay
 ---
@@ -15,11 +15,11 @@ The look and feel of your Quire publication can be customized at four different 
 - The default theme installed with every new Quire project is the [Quire Starter Theme](https://github.com/gettypubs/quire-starter-theme). The README file of that repository includes complete information about the customizations available in that specific theme.
 {{< /q-class >}}
 
-## Changing the Style Variables in the Theme
+## Change the Style Variables in the Theme
 
-Every Quire project has a theme inside the `themes` directory. When you first start a new project typing the `quire new` command in your command-line interface, the default theme included is the [Quire Starter Theme](https://github.com/gettypubs/quire-starter-theme). In it, you can access simple text variables that will let you update text and background colors, some element sizes, fonts, paragraph indents and more.
+Every Quire project has a theme inside the `themes` directory. When you first start a new project typing the `quire new` command in your command-line interface, the default theme included is the [Quire Starter Theme](https://github.com/gettypubs/quire-starter-theme). In it, you can access simple text variables that will let you update text and background colors, some element sizes, fonts, paragraph indents, and more.
 
-To find the variables, open the `themes/quire-starter-theme` directory, navigate to the `source` sub-directory and then `css`, and open the file called `variables.scss`.
+To find the variables, open the `themes/quire-starter-theme` directory, navigate to the `source` sub-directory, and then `css`, and open the file called `variables.scss`.
 
 {{< q-figure id="1.12" >}}
 
@@ -39,7 +39,7 @@ Colors are expressed a number of different ways, none of which are better or mor
 - You must have the `quire preview` command running in your command-line interface to see changes you make to the `variables.scss` file. You may also sometimes need to refresh your browser page, or even clear the browser cache to get the style changes to fully load.
 {{< /q-class >}}
 
-## Adding Custom Styles
+## Add Custom Styles
 
 In your project’s `static` directory, there is a `css` directory with a blank `custom.css` file.
 
@@ -103,9 +103,9 @@ In the above example, we are selecting the element with a {{< q-glossary "class"
 
 {{< /q-class >}}
 
-## Overriding Theme Templates
+## Override Theme Templates
 
-{{< q-glossary "CSS" >}} changes like those mentioned above are best for re-styling existing elements. If though you’d like to make a more structural change, say, to rearrange elements on the page, or add new elements altogether, you’ll need to alter the {{< q-glossary "template" >}} files that come in the {{< q-glossary "theme" >}}. That said, other than changing the {{< q-glossary "Variables" >}} in `variables.scss` file, as described above, it’s usually best not to make other changes directly in the theme itself. By not doing so, it’s much easier to update your theme or switch out other themes later, not to mention easier to undo changes you’ve made.
+{{< q-glossary "CSS" >}} changes like those mentioned above are best for restyling existing elements. If though you’d like to make a more structural change, say, to rearrange elements on the page, or add new elements altogether, you’ll need to alter the {{< q-glossary "template" >}} files that come in the {{< q-glossary "theme" >}}. That said, other than changing the {{< q-glossary "Variables" >}} in `variables.scss` file, as described above, it’s usually best not to make other changes directly in the theme itself. By not doing so, it’s easier to update your theme or switch out other themes later, not to mention easier to undo changes you’ve made.
 
 For modest changes to the theme {{< q-glossary "templates" >}}, we recommend creating new override files. Much like the `custom.css` file can be used to override styles in the project theme, you can also have files to override templates. There are none in the default starting project, so you’ll need to start be creating a new `layouts` directory folder in the main directory of your project. Any files you put in this `layouts` directory will override the corresponding files in the `layouts` directory of your theme. This includes page templates, partial templates and shortcodes.
 
@@ -134,7 +134,7 @@ For example, let’s say you want to customize the layout of all the pages in yo
 {{ end }}
 ```
 
-If you copy the `essay` sub-directory and its `single.html` file into the new `layouts` directory in your project’s main directory, this copy will override anything in the {{< q-glossary "theme" >}}. So, if you delete the bibliography and rearrange the header and abstract in the copied file, that’s what Quire will use when building the site. It only changes the style of the header and abstract of your pages while the bibliography style remains intact.
+If you copy the `essay` subdirectory and its `single.html` file into the new `layouts` directory in your project’s main directory, this copy will override anything in the {{< q-glossary "theme" >}}. So, if you delete the bibliography and rearrange the header and abstract in the copied file, that’s what Quire will use when building the site. It only changes the style of the header and abstract of your pages while the bibliography style remains intact.
 
 ```go
 {{ define "main" }}
@@ -164,11 +164,11 @@ Whether in the {{< q-glossary "theme" >}} or in your project directory, all shor
 
 And if you make a mistake or change your mind later, you can simply delete the copy of the file and Quire will go back to using the original template as provided in the theme. This method can also be used to add completely new templates and even new shortcodes.
 
-## Creating a New Quire Theme
+## Create a New Quire Theme
 
 TK
 
-## Updating Your Theme to a Newer Version
+## Update Your Theme to a Newer Version
 
 Before updating your {{< q-glossary "theme" >}}, make note of any changes you made to it as these will need to be manually copied over to the updated version of the theme if you want to keep them. Usually, this would only be changes to the [style variables](#changing-the-style-variables-in-the-theme).
 
@@ -184,7 +184,7 @@ Before updating your {{< q-glossary "theme" >}}, make note of any changes you ma
 
 You may also need to clear your browser cache to get the new theme stylesheets to reload.
 
-## Changing to a New Theme
+## Change to a New Theme
 
 1. In the theme repository on GitHub, use the “Clone or download” button to download a ZIP file of the most current version of the theme, or, go to the repository’s Releases page to choose a particular release.
 

--- a/content/documentation/zooming-images-maps.md
+++ b/content/documentation/zooming-images-maps.md
@@ -1,5 +1,5 @@
 ---
-title: Zooming Images & Maps
+title: Zoom Images & Maps
 weight: 4900
 type: essay
 ---

--- a/content/learn/tutorial.md
+++ b/content/learn/tutorial.md
@@ -11,7 +11,7 @@ As you get started with Quire, it is important to familiarize yourself with the 
 
 In the following sections, we’ll learn more about these interconnected components, and get you up and running in a demo Quire project.
 
-## 1. Working in a Command-Line Shell
+## 1. Work in a Command-Line Shell
 
 The first thing you’ll need is a command-line shell. Along with using it to run Quire, we’ll also use it to install some of Quire’s dependencies (the other programs required for Quire to function, such as Pandoc to create the e-book files and Node.js to run javascript).
 
@@ -39,7 +39,7 @@ With the shell open, you can type `ls` (list) to list the folders and files in y
 
 *For a deeper dive into the command-line, check out a ["Really Friendly Command Line Intro"](https://hellowebbooks.com/learn-command-line/), or the Programming Historian’s ["Introduction to the Bash Command Line"](https://programminghistorian.org/en/lessons/intro-to-bash).*
 
-## 2. Installing Quire
+## 2. Install Quire
 
 Follow the links below to install Quire:
 
@@ -47,7 +47,7 @@ Follow the links below to install Quire:
 - [Windows](/guide/install-uninstall#windows-installation)
 - [Linux](/guide/install-uninstall#linux-installation)
 
-## 3. Creating a New Project
+## 3. Create a New Project
 
 To start a new Quire project, open your command-line shell and type `quire new my-project`. Quire will download a new starter project into a folder named “my-project” in your home directory. If you are using the Beta version of Quire, you may need to enter your GitHub username and password twice during the download process: once for the starter kit and again for the starter theme.
 
@@ -66,7 +66,7 @@ To see the preview of your new starter, open your browser and go to [http://loca
 
 {{< q-figure id="quire-starter" >}}
 
-## 4. Working in a Text Editor
+## 4. Work in a Text Editor
 
 Some placeholder content comes with each new Quire project. To start customizing it, you’ll need a text editor. This goes with the command-line shell you have for installing and entering Quire commands, and the browser you use for previewing.
 
@@ -81,7 +81,7 @@ Once installed, open your text editor, navigate to File, and open the `my-projec
 
 {{< q-figure id="text-editor" >}}
 
-## 5. Entering Publication Metadata
+## 5. Enter Publication Metadata
 
 The metadata for your publication (its title, subtitle, contributors, publication date, etc.) is used in various areas of your site. It’s used under the hood for {{< q-glossary "search engine optimization" >}} (SEO), as well as on the site itself in headings, navigation labels, and on your About or Copyright page.
 
@@ -109,7 +109,7 @@ The three other metadata files in the `data` directory—`figures.yml`, `referen
 
 *Read more in the [“Metadata & Configuration”](/guide/metadata-configuration/) chapter of this guide and our [“Quire YAML”](/api-docs/yaml/) reference.*
 
-## 6. Editing Content
+## 6. Edit Content
 
 Next let’s look at the `content` directory of your publication. In this directory are a series of {{< q-glossary "Markdown" >}} files (`.md`) that hold the content of the publication. Each one represents a page of your website. The filename becomes part of the URL for that page in your final publication, so it’s always lowercase and includes no spaces or special characters.
 
@@ -172,7 +172,7 @@ You’ll see this added a figure and caption, the text for which is stored in th
 
 *Read more about Page YAML, Markdown, and Quire shortcodes in the [“Pages”](/guide/pages/) chapter of this guide, and more about figure shortcodes in [“Figure Images”](/guide/figure-images/).*
 
-## 7. Customizing Styles
+## 7. Customize Styles
 
 There are number of different ways to customize the look of your publication. Some of the easiest are to add your own background images to your cover and page banners, and to change the colors and other styles of different interface elements (like the menu, navigation bar, and links) with {{< q-glossary "CSS" >}} variables.
 
@@ -210,7 +210,7 @@ Make sure there’s always a space between the colon and the value you enter, an
 
 *Read more about applying your own custom CSS styles, altering page templates, and creating a new theme in the [“Customizing Styles”](/guide/styles-customization/) chapter of this guide.*
 
-## 8. Outputting Your Publication
+## 8. Output Your Publication
 
 In your Terminal, stop the `quire preview` process by typing Control-C. To create the PDF version of your publication type `quire pdf` and press enter. For the EPUB, type `quire epub` and press enter. Both files will be created and saved into your project’s `static/downloads` directory. View them by right clicking (or control clicking on a Mac) on the file name in the lefthand sidebar of your text editor and selecting “Show in Finder” or “Show in File Explorer”.
 


### PR DESCRIPTION
Issue #247 Still IN-PROGRESS

- Changed formatted words in certain areas, should I remove formatting across documentation pages for subheadings?
- on the For developers page make sure the Copyright&About and Working with Text links are functional.
