### PR TITLE
Copy edits to Community pages

### DIFF
--- a/content/community/code-of-conduct.md
+++ b/content/community/code-of-conduct.md
@@ -11,7 +11,7 @@ Version 1.0 (dated September 2, 2020)
 
 **All are welcome.** As an open-source community, Quire is committed to providing a safe, welcoming, transparent, and inclusive environment for all our community members and those wishing to become involved. We value diverse perspectives, as well as expertise and experience at all levels.
 
-Our Code of Conduct provides guidance to help foster friendly and respectful interactions and outlines the consequences for anyone found violating this code. Our Code of Conduct applies across all Quire related communication platforms including the GitHub Discussions forum, GitHub repositories, the Quire email list, and any private correspondence. It also applies to remote and in-person meetings, events, conferences, and any instances in which a community member represents Quire out in the world. We strive to maintain a positive, collaborative, and enriching experience for our community. To help us reach this goal, we ask that all community members adhere to the following guidelines for participation.
+Our Code of Conduct provides guidance to help foster friendly and respectful interactions and outlines the consequences for anyone found violating this code. Our Code of Conduct applies across all Quire-related communication platforms including the GitHub Discussions forum, GitHub repositories, the Quire email list, and any private correspondence. It also applies to remote and in-person meetings, events, conferences, and any instances in which a community member represents Quire out in the world. We strive to maintain a positive, collaborative, and enriching experience for our community. To help us reach this goal, we ask that all community members adhere to the following guidelines for participation.
 
 If you believe that someone is violating the Quire Code of Conduct, we ask that you please report this behavior immediately by emailing quire@getty.edu. For more information, please see our **Reporting Guidelines** below.
 
@@ -19,7 +19,7 @@ If you believe that someone is violating the Quire Code of Conduct, we ask that 
 
 - **We are friendly and patient.**
 
-- **We are welcoming**: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+- **We are welcoming**: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
 - **We are considerate**: Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we’re an international community, so you might not be communicating in someone else’s primary language.
 
@@ -27,10 +27,10 @@ If you believe that someone is violating the Quire Code of Conduct, we ask that 
 
 - **We are careful in the words that we choose**: We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other community members. Harassment and other exclusionary behavior aren’t acceptable.
 
-- **We try to understand why we disagree**: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of our community comes from its diversity. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+- **We try to understand why we disagree**: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of our community comes from its diversity. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err, and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
 
-### ANTI-HARRASSMENT
+### ANTI-HARASSMENT
 
 The Quire community is dedicated to providing a harassment-free collaboration experience for everyone regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, faith, or anything else. We do not tolerate harassment of community members in any form. Sexual or discriminatory language and imagery is not appropriate at any time.
 

--- a/content/community/contributor-guidelines.md
+++ b/content/community/contributor-guidelines.md
@@ -31,13 +31,13 @@ More TK
 
 ### Ground Rules
 
-Always be friendly and patient. Be welcoming, considerate, and respectful. Be careful with the words you choose. Try to understand why we disagree. Do not make offensive comments, insults, or jokes. Do not deliberately threaten or intimidate. Do not use sexually explicit or violent language or images. Harrassment will not be tolerated.  For more guidelines on appropriate behavior, please see our [Code of Conduct](https://quire/getty.edu/community/code-of-conduct).
+Always be friendly and patient. Be welcoming, considerate, and respectful. Be careful with the words you choose. Try to understand why we disagree. Do not make offensive comments, insults, or jokes. Do not deliberately threaten or intimidate. Do not use sexually explicit or violent language or images. Harassment will not be tolerated.  For more guidelines on appropriate behavior, please see our [Code of Conduct](https://quire/getty.edu/community/code-of-conduct).
 
 -----------
 
 ### Responsibilities (**Text below is placeholder text**)
 
-- Ensure cross-platform compatibility for every change that's accepted. Windows, Mac, Debian & Ubuntu Linux.
+- Ensure cross-platform compatibility for every change that is accepted. Windows, Mac, Debian & Ubuntu Linux.
 - Ensure that code that goes into core meets all requirements in this checklist: https://gist.github.com/audreyr/4feef90445b9680475f2
 - Create issues for any major changes and enhancements that you wish to make. Discuss things transparently and get community feedback.
 - Don't add any classes to the codebase unless absolutely needed. Err on the side of using functions.

--- a/content/community/contributor-guidelines.md
+++ b/content/community/contributor-guidelines.md
@@ -23,7 +23,7 @@ There are many ways to contribute from adding to the code, submitting bug report
 
 Always check the **[documentation](https://quire/getty.edu/documentation)** first.
 
-Refer to the **[forum](#)** for support, to ask and answer questions, and for general information.
+Refer to the **[forum](/community/forum/)** for support, to ask and answer questions, and for general information.
 
 For bugs, please refer to **[GitHub Issues](https://github.com/gettypubs/quire/issues)**.
 

--- a/content/community/forum.md
+++ b/content/community/forum.md
@@ -4,7 +4,7 @@ weight: 2200
 type: essay
 ---
 
-Welcome to the Quire forum! Here you will find community-based support to help you navigate the ins-and-outs of Quire. We encourage you to ask and answer questions, share ideas, raise issues, collaborate, and assist your fellow community members.
+Welcome to the Quire forum! Here you will find community-based support to help you navigate the ins and outs of Quire. We encourage you to ask and answer questions, share ideas, raise issues, collaborate, and assist your fellow community members.
 
 Examples of topics you will find covered in our forums include: **support, tips & tricks, announcements, show-and-tell, development, customization, installation, deployment, and more.** We ask that you do not utilize the forum for bug reports. Those must be submitted via **[GitHub Issues](https://github.com/gettypubs/quire/issues)**.
 
@@ -33,4 +33,4 @@ Examples of topics you will find covered in our forums include: **support, tips 
 
 - No attacks on other people.
 
-Please see our **[Quire Code of Conduct](https://quire/getty.edu/community/code-of-conduct)** for more information regarding appropriate behavior, as well as our anti-harrassment policy.
+Please see our **[Quire Code of Conduct](https://quire/getty.edu/community/code-of-conduct)** for more information regarding appropriate behavior, as well as our anti-harassment policy.

--- a/content/community/join-us.md
+++ b/content/community/join-us.md
@@ -74,7 +74,7 @@ We hope to see you at future Quire workshops and events. We'd also love to know 
 [Submit Your Work](#)
 </div>
 
-We love celebrating Quire accomplishments. Send us your finished Quire publications and we will add them to our **[User Showcase](community/user-showcase/)** and feature them on our homepage. We also welcome the submission of papers, articles, and presentations that you have written about Quire.
+We love celebrating Quire accomplishments. Send us your finished Quire publications and we will add them to our **[User Showcase](/community/user-showcase/)** and feature them on our homepage. We also welcome the submission of papers, articles, and presentations that you have written about Quire.
 
 Please email quire@getty.edu to learn more.
 

--- a/content/community/join-us.md
+++ b/content/community/join-us.md
@@ -6,7 +6,7 @@ type: essay
 
 ## Welcome to the Quire Community!
 
-We invite you to join our diverse and vibrant community of scholars, publishers, museum professionals, developers, designers, and more, that are using Quire to create innovative digital publishing projects.
+We invite you to join our diverse and vibrant community of scholars, publishers, museum professionals, developers, designers, and more, who are using Quire to create innovative digital publishing projects.
 
 As an open-source community and ever-evolving initiative, our community members' participation, feedback, and contributions are what enable us to continue fine-tuning, developing, and spreading the word about Quire. We encourage you to get involved. No matter what level of experience you have, we welcome all contributions, big and small. We couldn't do it without you!
 
@@ -22,7 +22,7 @@ As an open-source community and ever-evolving initiative, our community members'
 [Become a User](/request-access/beta-access/)
 </div>
 
-We welcome users at all levels of technical expertise and publishing experience.  Sign up for free beta access and get started with Quire today!
+We welcome users at all levels of technical expertise and publishing experience. Sign up for free beta access and get started with Quire today!
 
 <div class="feature-cards xsmall-card">
 
@@ -35,7 +35,7 @@ We welcome users at all levels of technical expertise and publishing experience.
 
 </div>
 
-Here you will find community-based support to help you navigate the ins-and-outs of Quire. Ask and answer questions, share ideas, raise issues, collaborate, and assist your fellow community members.
+Here you will find community-based support to help you navigate the ins and outs of Quire. Ask and answer questions, share ideas, raise issues, collaborate, and assist your fellow community members.
 
 <div class="feature-cards xsmall-card">
 
@@ -108,7 +108,7 @@ Quire on GitHub:
 [Submit a Bug](https://github.com/gettypubs/quire/issues)
 </div>
 
-Bugs are sneaky, and we need your help spotting them! If you come across something broken or just not looking right, please add it to our bug tracker, and we'll work on getting the issue resolved ASAP.
+Bugs are sneaky, and we need your help spotting them! If you come across something broken or that just doesn't look right, please add it to our bug tracker and we'll work on getting the issue resolved ASAP.
 
 Please remember to label your issue and include the following information when submitting a bug:
 

--- a/content/community/news-events.md
+++ b/content/community/news-events.md
@@ -36,7 +36,7 @@ Wishing all our Quire users a safe and happy holiday!
 
 **Monday, July 20**
 
-11:00am-12:00pm CST
+11:00am–12:00pm CST
 
 Think Digital
 
@@ -44,7 +44,7 @@ Part 1: Conceptualizing
 
 **Tuesday, July 28**
 
-11:00am-12:00pm CST
+11:00am–12:00pm CST
 
 Think Digital
 
@@ -57,4 +57,4 @@ Part 2: Implementing
 
 **Thursday, September 1**
 
-10:00am - 2:00pm PST
+10:00am–2:00pm PST


### PR DESCRIPTION
Addresses issue #235 

No major changes

- I did not edit the placeholder text. 
- Fixed User Showcase link on Join Us page. Code of Conduct and documentation links do not work. At the moment they link externally, but should they be linked to pages on the Quire website?
- Submit publication to be featured button does not include link