### PR TITLE
Fix broken button link

### DIFF
--- a/content/community/join-us.md
+++ b/content/community/join-us.md
@@ -19,7 +19,7 @@ As an open-source community and ever-evolving initiative, our community members'
 
 <div class="action-button">
 
-[Become a User](/request-access/beta-access/)
+[Become a User](https://forms.gle/m1fgZu5BHKhddMrW7)
 </div>
 
 We welcome users at all levels of technical expertise and publishing experience. Sign up for free beta access and get started with Quire today!


### PR DESCRIPTION
I forgot to check this button on the Join Us page but I wanted to make sure this change is correct. The link to the Request Access page does not work, but when I link it directly to the Google doc form it works. 