### PR TITLE
Add shortcode and initial info for community showcase grid

### DIFF
--- a/content/community/community-showcase.md
+++ b/content/community/community-showcase.md
@@ -4,7 +4,7 @@ weight: 2400
 type: essay
 ---
 
-Quire is used both internally at Getty and externally by scholars, publishers, curators, designers, and developers to produce everything from collection catalogues and research projects to online exhibitions, reports, and journal articles. We invite you to browse the titles below published by the Quire community and be inspired!
+Developed by Getty, Quire is now being used by a growing community of scholars, publishers, curators, designers, and developers to produce everything from collection catalogues and research projects to online exhibitions, reports, and journal articles. We invite you to browse the titles below published by the Quire community and be inspired!
 
 {{< q-showcase >}}
 

--- a/content/community/community-showcase.md
+++ b/content/community/community-showcase.md
@@ -6,14 +6,10 @@ type: essay
 
 Quire is used both internally at Getty and externally by scholars, publishers, curators, designers, and developers to produce everything from collection catalogues and research projects to online exhibitions, reports, and journal articles. We invite you to browse the titles below published by the Quire community and be inspired!
 
-<div class="action-button">
+{{< q-showcase >}}
 
-[Join our community](/community/join-us/)
+<div class="action-button-center">
+
+[Submit Your Quire Project](#)
+
 </div>
-
-<div class="action-button">
-
-[Submit publication to be featured](#)
-</div>
-
-{{< q-figure-group grid=2 id="thomas_rife, alcohols_empire, ancient_ambers, artists_studios_paris, bending_lines, cva, fault_lines, mozoomdar_at_sea, humanizing_the_digital, in_plain_sight, silk_poems, state_of_convergence, state_of_museum_dig, tilt_west,  tour_toolkit, heritage_management" >}}

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -12,7 +12,9 @@
 #   pub_date:               YYYY-MM-DD format, only year will display
 #   url:                    URL to homepage/cover of the publication
 #   customization_scale:    Scale 0–5 (see above for key)
-#   github_user:            GitHub username
+#   github_user:            GitHub username(s) in a list format as shown
+#     - name
+#     - name
 #   note:                   Markdown ok, should focus on it as a Quire project:
 #                             What's new? What features did the use? How was it
 #                             customized?
@@ -36,7 +38,8 @@ project_list:
     pub_date: 2020-06-21
     url: http://www.thomasrife.com/
     customization_scale: 2
-    github_user: halfempty
+    github_user:
+      - halfempty
     note: "This project updates the starter theme with a new font and custom css for in the typography."
 
   - id: "artists_studios_paris"
@@ -47,7 +50,8 @@ project_list:
     pub_date: 2018-04-01
     url: https://www.journal18.org/issue5_williams/
     customization_scale: 1
-    github_user: nancyum
+    github_user:
+      - nancyum
     note: "This project has the distinction of being the first Quire project published outside Getty. It’s an article published as part of the Spring 2018 issue of *Journal18* on [Digital Mapping & Eighteenth-Century Visual, Material, and Built Cultures](https://www.journal18.org/past-issues/5-coordinates-spring-2018/)."
 
   - id: "bending_lines"
@@ -58,7 +62,8 @@ project_list:
     pub_date: 2020-05-01
     url: https://www.leventhalmap.org/digital-exhibitions/bending-lines/
     customization_scale: 3
-    github_user: garrettdashnelson
+    github_user:
+      - garrettdashnelson
     note: "This online exhibition was orignally slated to be a phyiscally gallery exhibition, but it was put on indefinite hold due the COVID-19 pandemic. The project features a wide range of style customizations."
 
   # - id: "fault_lines"

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -5,13 +5,13 @@
 # YAML KEY:
 # ---------
 # - id:                     lowercase, no spaces or special characters
-#   src:                    Screenshot of homepage
+#   src:                    Screenshot of homepage, 1200px x 668px or at least that ratio
 #   type:                   Try to use existing types if possible
-#   publisher:              Or "Self Published" if not publisher/institution
+#   publisher:              Or "Self published" if not publisher/institution
 #   title_info:             Markdown ok, typically: "*Title of Publication*, by Author Name"
 #   pub_date:               YYYY-MM-DD format, only year will display
 #   url:                    URL to homepage/cover of the publication
-#   customization_scale:    Scale 0–5 (see above for key)
+#   customization_level:    "none", "minor", "moderate", "significant", "extensive", or "full"
 #   github_user:            GitHub username(s) in a list format as shown
 #     - name
 #     - name
@@ -19,14 +19,14 @@
 #                             What's new? What features did the use? How was it
 #                             customized?
 #
-# CUSTOMIZATION SCALE:
+# CUSTOMIZATION LEVELS:
 # --------------------
-# 0: No customization
-# 1: Style variables manipulated
-# 2: New fonts used, some custom CSS
-# 3: Templates/shortcodes customized, more custom CSS
-# 4: New templates/shortcodes written, more custom CSS, custom JS
-# 5: Fully new theme/design
+# "none": No customization
+# "minor": Style variables manipulated
+# "moderate": New fonts used, some custom CSS
+# "significant": Templates/shortcodes customized, more custom CSS
+# "extensive": New templates/shortcodes written, more custom CSS, custom JS
+# "full": Fully new theme/design
 
 project_list:
 
@@ -38,7 +38,7 @@ project_list:
     title_info: "*The Alamo Keeper: Thomas C. Rife*, by Philip Mullins and George Mullins"
     pub_date: 2020-06-21
     url: http://www.thomasrife.com/
-    customization_scale: 2
+    customization_level: moderate
     github_user:
       - halfempty
     note: "This project updates the starter theme with a new font and custom css for in the typography."
@@ -51,7 +51,7 @@ project_list:
     title_info: "“Artists’ Studios in Paris: Digitally Mapping the 18th-Century Art World,” by Hannah Williams"
     pub_date: 2018-04-01
     url: https://www.journal18.org/issue5_williams/
-    customization_scale: 1
+    customization_level: minor
     github_user:
       - nancyum
     note: "This project has the distinction of being the first Quire project published outside Getty. It’s an article published as part of the Spring 2018 issue of *Journal18* on [Digital Mapping & Eighteenth-Century Visual, Material, and Built Cultures](https://www.journal18.org/past-issues/5-coordinates-spring-2018/)."
@@ -64,10 +64,10 @@ project_list:
     title_info: "*Bending Lines: Maps and Data from Distortion to Deception*"
     pub_date: 2020-05-01
     url: https://www.leventhalmap.org/digital-exhibitions/bending-lines/
-    customization_scale: 3
+    customization_level: moderate
     github_user:
       - garrettdashnelson
-    note: "This online exhibition was orignally slated to be a phyiscally gallery exhibition, but it was put on indefinite hold due the COVID-19 pandemic. The project features a wide range of style customizations."
+    note: "This online exhibition was orignally slated to be a physical gallery exhibition, but it was put on indefinite hold due the COVID-19 pandemic. The project features a wide range of style customizations."
 
   # - id: "fault_lines"
   #   src: /screenshots/_fault_lines.png

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -75,7 +75,7 @@ project_list:
     type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*Fault Lines: 2020 Senior Thesis Exhibition*, by Sequoia Belk-Hurst, Téa Blatt, L.A. Bonet, De'Ana Brownfield, Carla Cardenas, Lexi Castillo, Sarah Frances, Slaone Gershov, Danielle La Fontaine, Thea Moerman, Raissa Palacios, Yana Sternberger-Moye, Ellis Teare, and Rowan Weir"
-    pub_date: 2020
+    pub_date: 2020-01-01
     url: https://mcam.mills.edu/publications/faultlines/index.html
     customization_level: minor
     github_user:
@@ -88,7 +88,7 @@ project_list:
     type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*In Plain Sight: Kathryn Andrews, castaneda/reiman, Dario Robleto, Weston Teruya*, by Daniel Nevers, Joanna Fiduccia, Anne Lesley Selcer, and Stephanie Hanor"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://mcam.mills.edu/publications/inplainsight/index.html
     customization_level: minor
     github_user:
@@ -101,7 +101,7 @@ project_list:
     type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*State of Convergence*"
-    pub_date: 2020
+    pub_date: 2020-01-01
     url: https://mcam.mills.edu/publications/stateofconvergence/index.html
     customization_level: minor
     github_user:
@@ -114,7 +114,7 @@ project_list:
     type: Journal
     publisher: Tilt West
     title_info: "*Tilt West Journal, vol. 1, Art and Language*, by Nora Burnett Abrams, Noel Black, Angie Eng, Rick Griffith, Paul Miller, Juan Morales, Kelly Sears, Suzi Q. Smith, and Joel Swanson"
-    pub_date: 2020-03
+    pub_date: 2020-03-01
     url: http://journal.tiltwest.org/vol1/
     customization_level: minor
     github_user:
@@ -127,7 +127,7 @@ project_list:
     type: Exhibition Catalogue
     publisher: Hong Kong University Museum of Art Gallery
     title_info: "*Silk Poems*"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://1000camels.github.io/jen-bervin/
     customization_level: moderate
     github_user:
@@ -140,7 +140,7 @@ project_list:
     type: Collection Catalogue
     publisher: Getty Publications
     title_info: "*Ancient Carved Ambers in the J. Paul Getty Museum*, by Faya Causey"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://www.getty.edu/publications/ambers/
     customization_level: minor
     github_user:
@@ -153,7 +153,7 @@ project_list:
     type: Corpus Vasorum Antiquorum
     publisher: Getty Publications
     title_info: "*Corpus Vasorum Antiquorum, Fascicule 10: Athenian Red-Figure Column- and Volute-Kraters*, by Despoina Tsiafakis"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://www.getty.edu/publications/cva10/
     customization_level: extensive
     github_user:
@@ -166,7 +166,7 @@ project_list:
     type: Proceedings
     publisher: Getty Publications
     title_info: "*Values in Heritage Management: Emerging Approaches and Research Directions*, by Erica Avrami, Susan MacDonald, Randall Madison, and David Myers"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://www.getty.edu/publications/heritagemanagement/
     customization_level: moderate
     github_user:
@@ -179,7 +179,7 @@ project_list:
     type: Informational Pamphlet
     publisher: Minneapolis Institute of Art
     title_info: "*Tour Toolkit: Developing an Inclusive Tour*, by Minneapolis Institute of Art"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://artsmia.github.io/tour-toolkit/
     customization_level: moderate
     github_user:
@@ -205,7 +205,7 @@ project_list:
     type: Research Project
     publisher: Self-Published
     title_info: "*Mozoomdar at Sea*, by Nick Tackes"
-    pub_date: 2018
+    pub_date: 2018-01-01
     url: https://mozoomdar-at-sea.netlify.app/
     customization_level: minor
     github_user:
@@ -218,7 +218,7 @@ project_list:
     type: Proceedings
     publisher: Ad Hoc Museum Collective
     title_info: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, edited by Suse Anderson, Isabella Bruno, Hannah Hethmon, Seema Rao, Ed Rodley, and Rachel Ropeik"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://ad-hoc-museum-collective.github.io/humanizing-the-digital/
     customization_level: minor
     github_user:
@@ -231,7 +231,7 @@ project_list:
     type: Graduate Student Project
     publisher: Ad Hoc Museum Collective
     title_info: "*The State of Museum Digital Practice in 2019: A Collection of Graduate Essays and Responses*, by Suse Anderson, Cristin Guinan-Wiley, Jonathan Edelman, Rachel Rosenfeld, Mary McCulla, Sheridan Small, Cynthia Kurtz, Amy Pollard, Corrie Brady, Melissa Garcia, Caitlin Hepner, Sydney Thatcher, Laura Dickson, and Rebecca Brockette"
-    pub_date: 2019
+    pub_date: 2019-01-01
     url: https://ad-hoc-museum-collective.github.io/GWU-museum-digital-practice-2019/
     customization_level: minor
     github_user:

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -32,6 +32,7 @@ project_list:
 
   - id: "thomas_rife"
     src: /screenshots/_thomas_rife.png
+    alt: "Screenshot of publication cover: a color drawing of a western scene with four cowboys and a wagon"
     type: Family History
     publisher: Self published
     title_info: "*The Alamo Keeper: Thomas C. Rife*, by Philip Mullins and George Mullins"
@@ -44,6 +45,7 @@ project_list:
 
   - id: "artists_studios_paris"
     src: /screenshots/_artists_studios_paris.png
+    alt: "Screenshot of publication cover: an old painting of a large building in Paris and a cloud yellow-blue sky"
     type: Journal Article
     publisher: Journal18
     title_info: "“Artists’ Studios in Paris: Digitally Mapping the 18th-Century Art World,” by Hannah Williams"
@@ -56,6 +58,7 @@ project_list:
 
   - id: "bending_lines"
     src: /screenshots/_bending_lines.png
+    alt: "Screenshot of publication cover: a stylized map of the world in shades of deep blue, with a thick red dashed line curving across it"
     type: Online Exhibition
     publisher: Leventhal Map & Education Center, Boston Public Library
     title_info: "*Bending Lines: Maps and Data from Distortion to Deception*"

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -7,7 +7,7 @@
 # - id:                     lowercase, no spaces or special characters
 #   src:                    Screenshot of homepage, 1200px x 668px or at least that ratio
 #   type:                   Try to use existing types if possible
-#   publisher:              Or "Self published" if not publisher/institution
+#   publisher:              Or "Self-Published" if not publisher/institution
 #   title_info:             Markdown ok, typically: "*Title of Publication*, by Author Name"
 #   pub_date:               YYYY-MM-DD format, only year will display
 #   url:                    URL to homepage/cover of the publication
@@ -34,7 +34,7 @@ project_list:
     src: /screenshots/_thomas_rife.png
     alt: "Screenshot of publication cover: a color drawing of a western scene with four cowboys and a wagon"
     type: Family History
-    publisher: Self published
+    publisher: Self-Published
     title_info: "*The Alamo Keeper: Thomas C. Rife*, by Philip Mullins and George Mullins"
     pub_date: 2020-06-21
     url: http://www.thomasrife.com/
@@ -75,11 +75,11 @@ project_list:
     type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*Fault Lines: 2020 Senior Thesis Exhibition*, by Sequoia Belk-Hurst, Téa Blatt, L.A. Bonet, De'Ana Brownfield, Carla Cardenas, Lexi Castillo, Sarah Frances, Slaone Gershov, Danielle La Fontaine, Thea Moerman, Raissa Palacios, Yana Sternberger-Moye, Ellis Teare, and Rowan Weir"
-    pub_date: 2020-01-01
+    pub_date: 2020-05-20
     url: https://mcam.mills.edu/publications/faultlines/index.html
     customization_level: minor
     github_user:
-      - stephaniehanor
+      - MillsArtMuseum
     note: "Due to the COVID-19 pandemic, the Mills College 2020 BFA Senior Thesis Exhibition was canceled. This digital catalogue doubles as an online exhibition, providing Mills' graduating studio arts majors and minors with an opportunity to showcase their work."
 
   - id: "in_plain_sight"
@@ -88,11 +88,11 @@ project_list:
     type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*In Plain Sight: Kathryn Andrews, castaneda/reiman, Dario Robleto, Weston Teruya*, by Daniel Nevers, Joanna Fiduccia, Anne Lesley Selcer, and Stephanie Hanor"
-    pub_date: 2019-01-01
+    pub_date: 2019-09-19
     url: https://mcam.mills.edu/publications/inplainsight/index.html
     customization_level: minor
     github_user:
-      - stephaniehanor
+      - MillsArtMuseum
     note: "This is an exhibition catalogue for a show at Mills College Art Museum. The exhibition was not initially slated to include a catalogue due to high production costs, but Quire provided an affordable opportunity."
 
   - id: "state_of_convergence"
@@ -101,7 +101,7 @@ project_list:
     type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*State of Convergence*"
-    pub_date: 2020-01-01
+    pub_date: 2020-01-20
     url: https://mcam.mills.edu/publications/stateofconvergence/index.html
     customization_level: minor
     github_user:
@@ -127,7 +127,7 @@ project_list:
     type: Exhibition Catalogue
     publisher: Hong Kong University Museum of Art Gallery
     title_info: "*Silk Poems*"
-    pub_date: 2019-01-01
+    pub_date: 2020-06-05
     url: https://1000camels.github.io/jen-bervin/
     customization_level: moderate
     github_user:
@@ -140,7 +140,7 @@ project_list:
     type: Collection Catalogue
     publisher: Getty Publications
     title_info: "*Ancient Carved Ambers in the J. Paul Getty Museum*, by Faya Causey"
-    pub_date: 2019-01-01
+    pub_date: 2019-11-26
     url: https://www.getty.edu/publications/ambers/
     customization_level: minor
     github_user:
@@ -153,7 +153,7 @@ project_list:
     type: Corpus Vasorum Antiquorum
     publisher: Getty Publications
     title_info: "*Corpus Vasorum Antiquorum, Fascicule 10: Athenian Red-Figure Column- and Volute-Kraters*, by Despoina Tsiafakis"
-    pub_date: 2019-01-01
+    pub_date: 2019-07-16
     url: https://www.getty.edu/publications/cva10/
     customization_level: extensive
     github_user:
@@ -166,7 +166,7 @@ project_list:
     type: Proceedings
     publisher: Getty Publications
     title_info: "*Values in Heritage Management: Emerging Approaches and Research Directions*, by Erica Avrami, Susan MacDonald, Randall Madison, and David Myers"
-    pub_date: 2019-01-01
+    pub_date: 2019-09-16
     url: https://www.getty.edu/publications/heritagemanagement/
     customization_level: moderate
     github_user:
@@ -179,7 +179,7 @@ project_list:
     type: Informational Pamphlet
     publisher: Minneapolis Institute of Art
     title_info: "*Tour Toolkit: Developing an Inclusive Tour*, by Minneapolis Institute of Art"
-    pub_date: 2019-01-01
+    pub_date: 2019-12-01
     url: https://artsmia.github.io/tour-toolkit/
     customization_level: moderate
     github_user:
@@ -205,7 +205,7 @@ project_list:
     type: Research Project
     publisher: Self-Published
     title_info: "*Mozoomdar at Sea*, by Nick Tackes"
-    pub_date: 2018-01-01
+    pub_date: 2019-04-01
     url: https://mozoomdar-at-sea.netlify.app/
     customization_level: minor
     github_user:
@@ -218,7 +218,7 @@ project_list:
     type: Proceedings
     publisher: Ad Hoc Museum Collective
     title_info: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, edited by Suse Anderson, Isabella Bruno, Hannah Hethmon, Seema Rao, Ed Rodley, and Rachel Ropeik"
-    pub_date: 2019-01-01
+    pub_date: 2019-04-01
     url: https://ad-hoc-museum-collective.github.io/humanizing-the-digital/
     customization_level: minor
     github_user:
@@ -231,7 +231,7 @@ project_list:
     type: Graduate Student Project
     publisher: Ad Hoc Museum Collective
     title_info: "*The State of Museum Digital Practice in 2019: A Collection of Graduate Essays and Responses*, by Suse Anderson, Cristin Guinan-Wiley, Jonathan Edelman, Rachel Rosenfeld, Mary McCulla, Sheridan Small, Cynthia Kurtz, Amy Pollard, Corrie Brady, Melissa Garcia, Caitlin Hepner, Sydney Thatcher, Laura Dickson, and Rebecca Brockette"
-    pub_date: 2019-01-01
+    pub_date: 2019-12-23
     url: https://ad-hoc-museum-collective.github.io/GWU-museum-digital-practice-2019/
     customization_level: minor
     github_user:

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -72,38 +72,41 @@ project_list:
   - id: "fault_lines"
     src: /screenshots/_fault_lines.png
     alt: "Screenshot of publication cover: a distorted and cropped photograph of a lower arm in front of a dark background"
-    type: Online Exhibition/Exhibition Catalogue
+    type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*Fault Lines: 2020 Senior Thesis Exhibition*, by Sequoia Belk-Hurst, Téa Blatt, L.A. Bonet, De'Ana Brownfield, Carla Cardenas, Lexi Castillo, Sarah Frances, Slaone Gershov, Danielle La Fontaine, Thea Moerman, Raissa Palacios, Yana Sternberger-Moye, Ellis Teare, and Rowan Weir"
     pub_date: 2020
     url: https://mcam.mills.edu/publications/faultlines/index.html
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - stephaniehanor
+    note: "Due to the COVID-19 pandemic, the Mills College 2020 BFA Senior Thesis Exhibition was canceled. This digital catalogue doubles as an online exhibition, providing Mills' graduating studio arts majors and minors with an opportunity to showcase their work."
 
   - id: "in_plain_sight"
     src: /screenshots/_in_plain_sight.png
-    alt: "Screenshot of publication cover: a wall of framed and hung artwork behind a sheet of partially opaque material"
+    alt: "Screenshot of publication cover: a wall of multiple framed and hung pieces of art viewed behind a sheet of partially opaque material"
     type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*In Plain Sight: Kathryn Andrews, castaneda/reiman, Dario Robleto, Weston Teruya*, by Daniel Nevers, Joanna Fiduccia, Anne Lesley Selcer, and Stephanie Hanor"
     pub_date: 2019
     url: https://mcam.mills.edu/publications/inplainsight/index.html
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - stephaniehanor
+    note: "This is an exhibition catalogue for a show at Mills College Art Museum. The exhibition was not initially slated to include a catalogue due to high production costs, but Quire provided an affordable opportunity."
 
   - id: "state_of_convergence"
     src: /screenshots/_state_of_convergence.png
     alt: "Screenshot of publication cover: a fist punches through a sheet, onto which an image of mountains and trees is projected"
-    type: Online Exhibition/Exhibition Catalogue
+    type: Exhibition Catalogue
     publisher: Mills College Art Museum
     title_info: "*State of Convergence*"
     pub_date: 2020
     url: https://mcam.mills.edu/publications/stateofconvergence/index.html
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - stephaniehanor
+    note: "This is an exhibition catalogue for a show at Mills College Art Museum. The exhibition was not initially slated to include a catalogue due to high production costs, but Quire provided an affordable opportunity."
 
   - id: "tilt_west"
     src: /screenshots/_tilt_west.png
@@ -113,21 +116,23 @@ project_list:
     title_info: "*Tilt West Journal, vol. 1, Art and Language*, by Nora Burnett Abrams, Noel Black, Angie Eng, Rick Griffith, Paul Miller, Juan Morales, Kelly Sears, Suzi Q. Smith, and Joel Swanson"
     pub_date: 2020-03
     url: http://journal.tiltwest.org/vol1/
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - swambold1
+    note: "Inaugural issue of *Title West Journal.* Previously, content existed on their SoundCloud stream or via comissioned Medium articles. Quire enabled the *Tilt West* team to meaningfully expand their programming."
 
   - id: "silk_poems"
     src: /screenshots/_silk_poems.png
-    alt:
+    alt: "Screenshot of publication cover: a dark grey mottled line loops multiple times across the page set against a light grey background"
     type: Exhibition Catalogue
     publisher: Hong Kong University Museum of Art Gallery
     title_info: "*Silk Poems*"
     pub_date: 2019
-    url:
-    customization_level:
+    url: https://1000camels.github.io/jen-bervin/
+    customization_level: moderate
     github_user:
-    note:
+      - cjmattison
+    note: "This is the first volume in UMAG's Digital Chapbook series."
 
   - id: "ancient_ambers"
     src: /screenshots/_ancient_ambers.png
@@ -137,9 +142,10 @@ project_list:
     title_info: "*Ancient Carved Ambers in the J. Paul Getty Museum*, by Faya Causey"
     pub_date: 2019
     url: https://www.getty.edu/publications/ambers/
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - geealbers
+    note: "Devleoped by Getty, this publication is a good example of a standard collection catalogue built using Quire."
 
   - id: "cva"
     src: /screenshots/_cva.png
@@ -149,21 +155,23 @@ project_list:
     title_info: "*Corpus Vasorum Antiquorum, Fascicule 10: Athenian Red-Figure Column- and Volute-Kraters*, by Despoina Tsiafakis"
     pub_date: 2019
     url: https://www.getty.edu/publications/cva10/
-    customization_level:
+    customization_level: extensive
     github_user:
-    note:
+      - geealbers
+    note: "This publication marks the first-ever born digital, open-access version of the century-old reference series. Getty worked closely with developers and software engineers to create a special template for CVA volumes that can be used by other instiutions down the road."
 
   - id: "heritage_management"
     src: /screenshots/_heritage_management.png
     alt: "Screenshot of publication cover: a patinated bronze sculpture covered in graffiti is being lifted off its pedestal with a crane as onlookers watch"
-    type: Research Proceedings
+    type: Proceedings
     publisher: Getty Publications
     title_info: "*Values in Heritage Management: Emerging Approaches and Research Directions*, by Erica Avrami, Susan MacDonald, Randall Madison, and David Myers"
     pub_date: 2019
     url: https://www.getty.edu/publications/heritagemanagement/
-    customization_level:
+    customization_level: moderate
     github_user:
-    note:
+      - geealbers
+    note: "This publication represents typical reserach proceedings, however, it was additionally customized to accomodate a 7" x 10" print size."
 
   - id: "tour_toolkit"
     src: /screenshots/_tour_toolkit.png
@@ -173,21 +181,23 @@ project_list:
     title_info: "*Tour Toolkit: Developing an Inclusive Tour*, by Minneapolis Institute of Art"
     pub_date: 2019
     url: https://artsmia.github.io/tour-toolkit/
-    customization_level:
+    customization_level: moderate
     github_user:
-    note:
+      - kristhayer11
+    note: "This publication is an excellent example of how Quire can be used to produce shorter form publications like pamphlets and other educational handouts. Customziations include font, branding, and other aesthetic considerations."
 
   - id: "alcohols_empire"
     src: /screenshots/_alcohols_empire.png
     alt: "Screenshot of publication cover: three cocktails sit on a stone table with sprigs of rosemary superimposed onto the photograph"
-    type: Digital Native Project
+    type: Interactive Publication
     publisher: Minneapolis Institute of Art
     title_info: "*Alcohol's Empire: Distilled Spirits in the 1700s Atlantic World*, edited by Nicole LaBouff and Emily Beck"
     pub_date: 2019-02-04
     url: https://artsmia.github.io/alcohols-empire/
-    customization_level:
+    customization_level: moderate
     github_user:
-    note:
+      - kristhayer11
+    note: "With this project, Mia staff sought to evaluate Quire and its potential for future use at the museum. *Alcohol’s Empire* was a good test publication as it was a collaborative project with three distinct contributing partners. The project also included two public events and received national media coverage, which positively impacted its distribution."
 
   - id: "mozoomdar_at_sea"
     src: /screenshots/_mozoomdar_at_sea.png
@@ -197,30 +207,33 @@ project_list:
     title_info: "*Mozoomdar at Sea*, by Nick Tackes"
     pub_date: 2018
     url: https://mozoomdar-at-sea.netlify.app/
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - jtackesiii
+    note: "This digital exhibit includes mainly archival materials, manuscripts, and maps. The publication content lent itself well to a digital storytelling platform."
 
   - id: "humanizing_the_digital"
     src: /screenshots/_humanizing_the_digital.png
     alt: "Screenshot of publication cover: black text on a white background with anthropomorphized computer file folders smattered across two wavy registers of qr-code"
-    type: Conference Proceedings
+    type: Proceedings
     publisher: Ad Hoc Museum Collective
     title_info: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, edited by Suse Anderson, Isabella Bruno, Hannah Hethmon, Seema Rao, Ed Rodley, and Rachel Ropeik"
     pub_date: 2019
     url: https://ad-hoc-museum-collective.github.io/humanizing-the-digital/
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - shineslike
+    note: "This publication contains 17 conference-inspired responses to the state of museum technology in 2018, including essays, reflections, case studies, conversations, and an experimental in-book zine."
 
   - id: "state_of_museum_dig"
     src: /screenshots/_state_of_museum_dig.png
     alt: "Screenshot of publication cover: myriad strands of twinkle lights hung in two horizontal registers across a large architectural space"
-    type: Graduate Student/Class Project
+    type: Graduate Student Project
     publisher: Ad Hoc Museum Collective
     title_info: "*The State of Museum Digital Practice in 2019: A Collection of Graduate Essays and Responses*, by Suse Anderson, Cristin Guinan-Wiley, Jonathan Edelman, Rachel Rosenfeld, Mary McCulla, Sheridan Small, Cynthia Kurtz, Amy Pollard, Corrie Brady, Melissa Garcia, Caitlin Hepner, Sydney Thatcher, Laura Dickson, and Rebecca Brockette"
     pub_date: 2019
     url: https://ad-hoc-museum-collective.github.io/GWU-museum-digital-practice-2019/
-    customization_level:
+    customization_level: minor
     github_user:
-    note:
+      - shineslike
+    note: "This publication was written, edited and published by students in George Washington University's "Museums and Digital Technology" class. Each student was responsible for creating a 3,000-4,000-word essay that explores a specific area of museum digital practice today."

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -1,0 +1,127 @@
+#
+# PROJECT INFOMATION FOR COMMUNITY SHOWCASE:
+# ==================================================================
+#
+# YAML KEY:
+# ---------
+# - id:                     lowercase, no spaces or special characters
+#   src:                    Screenshot of homepage
+#   type:                   Try to use existing types if possible
+#   publisher:              Or "Self Published" if not publisher/institution
+#   title_info:             Markdown ok, typically: "*Title of Publication*, by Author Name"
+#   pub_date:               YYYY-MM-DD format, only year will display
+#   url:                    URL to homepage/cover of the publication
+#   customization_scale:    Scale 0–5 (see above for key)
+#   github_user:            GitHub username
+#   note:                   Markdown ok, should focus on it as a Quire project:
+#                             What's new? What features did the use? How was it
+#                             customized?
+#
+# CUSTOMIZATION SCALE:
+# --------------------
+# 0: No customization
+# 1: Style variables manipulated
+# 2: New fonts used, some custom CSS
+# 3: Templates/shortcodes customized, more custom CSS
+# 4: New templates/shortcodes written, more custom CSS, custom JS
+# 5: Fully new theme/design
+
+project_list:
+
+  - id: "thomas_rife"
+    src: /screenshots/_thomas_rife.png
+    type: Family History
+    publisher: Self published
+    title_info: "*The Alamo Keeper: Thomas C. Rife*, by Philip Mullins and George Mullins"
+    pub_date: 2020-06-21
+    url: http://www.thomasrife.com/
+    customization_scale: 2
+    github_user: halfempty
+    note: "This project updates the starter theme with a new font and custom css for in the typography."
+
+  - id: "artists_studios_paris"
+    src: /screenshots/_artists_studios_paris.png
+    type: Journal Article
+    publisher: Journal18
+    title_info: "“Artists’ Studios in Paris: Digitally Mapping the 18th-Century Art World,” by Hannah Williams"
+    pub_date: 2018-04-01
+    url: https://www.journal18.org/issue5_williams/
+    customization_scale: 1
+    github_user: nancyum
+    note: "This project has the distinction of being the first Quire project published outside Getty. It’s an article published as part of the Spring 2018 issue of *Journal18* on [Digital Mapping & Eighteenth-Century Visual, Material, and Built Cultures](https://www.journal18.org/past-issues/5-coordinates-spring-2018/)."
+
+  - id: "bending_lines"
+    src: /screenshots/_bending_lines.png
+    type: Online Exhibition
+    publisher: Leventhal Map & Education Center, Boston Public Library
+    title_info: "*Bending Lines: Maps and Data from Distortion to Deception*"
+    pub_date: 2020-05-01
+    url: https://www.leventhalmap.org/digital-exhibitions/bending-lines/
+    customization_scale: 3
+    github_user: garrettdashnelson
+    note: "This online exhibition was orignally slated to be a phyiscally gallery exhibition, but it was put on indefinite hold due the COVID-19 pandemic. The project features a wide range of style customizations."
+
+  # - id: "fault_lines"
+  #   src: /screenshots/_fault_lines.png
+  #   caption: "Senior thesis show | Mills College Art Museum"
+  #   full_caption: "*Fault Lines: 2020 Senior Thesis*, by Sequoia Belk-Hurst, Téa Blatt, L.A. Bonet, De'Ana Brownfield, Carla Cardenas, Lexi Castillo, Sarah Frances, Slaone Gershov, Danielle La Fontaine, Thea Moerman, Raissa Palacios, Yana Sternberger-Moye, Ellis Teare, and Rowan Weir. Oakland, CA: Mills College Art Museum, 2020."
+  #
+  # - id: "in_plain_sight"
+  #   src: /screenshots/_in_plain_sight.png
+  #   caption: "Exhibition catalogue | Mills College Art Museum"
+  #   full_caption: "*In Plain Sight: Kathryn Andrews, castaneda/reiman, Dario Robleto, Weston Teruya*, by Daniel Nevers, Joanna Fiduccia, Anne Lesley Selcer, and Stephanie Hanor. Oakland: Mills College Art Museum, 2019."
+  #
+  # - id: "state_of_convergence"
+  #   src: /screenshots/_state_of_convergence.png
+  #   caption: "Exhibition catalogue | Mills College Art Museum"
+  #   full_caption: "*State of Convergence*, Oakland: Mills College Art Museum, 2020."
+  #
+  # - id: "tilt_west"
+  #   src: /screenshots/_tilt_west.png
+  #   caption: "Journal | Tilt West ([view](http://journal.tiltwest.org/vol1/))"
+  #   full_caption: "“Art and Language.” In *Art and Language*, by Nora Burnett Abrams, Noel Black, Angie Eng, Rick Griffith, Paul Miller, Juan Morales, Kelly Sears, Suzi Q. Smith, and Joel Swanson. Denver: Tilt West, 2020."
+  #
+  # - id: "silk_poems"
+  #   src: /screenshots/_silk_poems.png
+  #   caption: "Exhibition catalogue | The University of Hong Kong Museum and Art Gallery"
+  #   full_caption: "*Silk Poems: Jen Bervin*, by Jen Bervin, The University Museum and Art Gallery, The University of Hong Kong, 2019."
+  #
+  # - id: "ancient_ambers"
+  #   src: /screenshots/_ancient_ambers.png
+  #   caption: "Collection catalogue | Getty Publications"
+  #   full_caption: "*Ancient Carved Ambers in the J. Paul Getty Museum*, J. Paul Getty Museum."
+  #
+  # - id: "cva"
+  #   src: /screenshots/_cva.png
+  #   caption: "Corpus Vasorum Antiquorum | Getty Publications"
+  #   full_caption: "*Corpus Vasorum Antiquorum, Fascicule 10: Athenian Red-Figure Column- and Volute-Kraters*, by Despoina Tsiafakis, J. Paul Getty Museum, 2019."
+  #
+  # - id: "heritage_management"
+  #   src: /screenshots/_heritage_management.png
+  #   caption: "Research proceedings | Getty Publications"
+  #   full_caption: "Values in Heritage Management: Emerging Approaches and Research Directions, by Erica Avrami, et al, The Getty Conservation Institute, 2019."
+  #
+  # - id: "tour_toolkit"
+  #   src: /screenshots/_tour_toolkit.png
+  #   caption: "Informational Pamphlet | Minneapolis Institute of Art"
+  #   full_caption: "*Tour Toolkit: Developing an Inclusive Tour*, by Minneapolis Institue of Art, 2019."
+  #
+  # - id: "alcohols_empire"
+  #   src: /screenshots/_alcohols_empire.png
+  #   caption: "Online Exhibition | Minneapolis Institute of Art"
+  #   full_caption: "*Alcohol's Empire: Distilled Spirits in the 1700s Atlantic World*. Minneapolis Institute of Art, 2019."
+  #
+  # - id: "mozoomdar_at_sea"
+  #   src: /screenshots/_mozoomdar_at_sea.png
+  #   caption: "Student Research Project"
+  #   full_caption: "*Mozoomdar at Sea*, by Nick Tackes, 2018."
+  #
+  # - id: "humanizing_the_digital"
+  #   src: /screenshots/_humanizing_the_digital.png
+  #   caption: "Conference Proceedings | Ad Hoc Museum Collective"
+  #   full_caption: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, by Suse Anderson, et al, Ad Hoc Museum Collective, 2019."
+  #
+  # - id: "state_of_museum_dig"
+  #   src: /screenshots/_state_of_museum_dig.png
+  #   caption: "Graduate Essays | Ad Hoc Museum Collective"
+  #   full_caption: "*The State of Museum Digital Practice in 2019: A collection of graduate essays and responses*, by Suse Anderson, et al, Ad Hoc Museum Collective, 2019."

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -201,26 +201,26 @@ project_list:
     github_user:
     note:
 
- - id: "humanizing_the_digital"
-   src: /screenshots/_humanizing_the_digital.png
-   alt: "Screenshot of publication cover: black text on a white background with anthropomorphized computer file folders smattered across two wavy registers of qr-code"
-   type: Conference Proceedings
-   publisher: Ad Hoc Museum Collective
-   title_info: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, edited by Suse Anderson, Isabella Bruno, Hannah Hethmon, Seema Rao, Ed Rodley, and Rachel Ropeik"
-   pub_date: 2019
-   url: https://ad-hoc-museum-collective.github.io/humanizing-the-digital/
-   customization_level:
-   github_user:
-   note:
+  - id: "humanizing_the_digital"
+    src: /screenshots/_humanizing_the_digital.png
+    alt: "Screenshot of publication cover: black text on a white background with anthropomorphized computer file folders smattered across two wavy registers of qr-code"
+    type: Conference Proceedings
+    publisher: Ad Hoc Museum Collective
+    title_info: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, edited by Suse Anderson, Isabella Bruno, Hannah Hethmon, Seema Rao, Ed Rodley, and Rachel Ropeik"
+    pub_date: 2019
+    url: https://ad-hoc-museum-collective.github.io/humanizing-the-digital/
+    customization_level:
+    github_user:
+    note:
 
- - id: "state_of_museum_dig"
-   src: /screenshots/_state_of_museum_dig.png
-   alt: "Screenshot of publication cover: myriad strands of twinkle lights hung in two horizontal registers across a large architectural space"
-   type: Graduate Student/Class Project
-   publisher: Ad Hoc Museum Collective
-   title_info: "*The State of Museum Digital Practice in 2019: A Collection of Graduate Essays and Responses*, by Suse Anderson, Cristin Guinan-Wiley, Jonathan Edelman, Rachel Rosenfeld, Mary McCulla, Sheridan Small, Cynthia Kurtz, Amy Pollard, Corrie Brady, Melissa Garcia, Caitlin Hepner, Sydney Thatcher, Laura Dickson, and Rebecca Brockette"
-   pub_date: 2019
-   url: https://ad-hoc-museum-collective.github.io/GWU-museum-digital-practice-2019/
-   customization_level:
-   github_user:
-   note:
+  - id: "state_of_museum_dig"
+    src: /screenshots/_state_of_museum_dig.png
+    alt: "Screenshot of publication cover: myriad strands of twinkle lights hung in two horizontal registers across a large architectural space"
+    type: Graduate Student/Class Project
+    publisher: Ad Hoc Museum Collective
+    title_info: "*The State of Museum Digital Practice in 2019: A Collection of Graduate Essays and Responses*, by Suse Anderson, Cristin Guinan-Wiley, Jonathan Edelman, Rachel Rosenfeld, Mary McCulla, Sheridan Small, Cynthia Kurtz, Amy Pollard, Corrie Brady, Melissa Garcia, Caitlin Hepner, Sydney Thatcher, Laura Dickson, and Rebecca Brockette"
+    pub_date: 2019
+    url: https://ad-hoc-museum-collective.github.io/GWU-museum-digital-practice-2019/
+    customization_level:
+    github_user:
+    note:

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -171,7 +171,7 @@ project_list:
     customization_level: moderate
     github_user:
       - geealbers
-    note: "This publication represents typical reserach proceedings, however, it was additionally customized to accomodate a 7" x 10" print size."
+    note: "This publication represents typical reserach proceedings, however, it was additionally customized to accomodate a 7 in. x 10 in. print size."
 
   - id: "tour_toolkit"
     src: /screenshots/_tour_toolkit.png
@@ -236,4 +236,4 @@ project_list:
     customization_level: minor
     github_user:
       - shineslike
-    note: "This publication was written, edited and published by students in George Washington University's "Museums and Digital Technology" class. Each student was responsible for creating a 3,000-4,000-word essay that explores a specific area of museum digital practice today."
+    note: "This publication was written, edited and published by students in George Washington University's Museums and Digital Technology class. Each student was responsible for creating an essay that explores a specific area of museum digital practice today."

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -69,67 +69,158 @@ project_list:
       - garrettdashnelson
     note: "This online exhibition was orignally slated to be a physical gallery exhibition, but it was put on indefinite hold due the COVID-19 pandemic. The project features a wide range of style customizations."
 
-  # - id: "fault_lines"
-  #   src: /screenshots/_fault_lines.png
-  #   caption: "Senior thesis show | Mills College Art Museum"
-  #   full_caption: "*Fault Lines: 2020 Senior Thesis*, by Sequoia Belk-Hurst, Téa Blatt, L.A. Bonet, De'Ana Brownfield, Carla Cardenas, Lexi Castillo, Sarah Frances, Slaone Gershov, Danielle La Fontaine, Thea Moerman, Raissa Palacios, Yana Sternberger-Moye, Ellis Teare, and Rowan Weir. Oakland, CA: Mills College Art Museum, 2020."
-  #
-  # - id: "in_plain_sight"
-  #   src: /screenshots/_in_plain_sight.png
-  #   caption: "Exhibition catalogue | Mills College Art Museum"
-  #   full_caption: "*In Plain Sight: Kathryn Andrews, castaneda/reiman, Dario Robleto, Weston Teruya*, by Daniel Nevers, Joanna Fiduccia, Anne Lesley Selcer, and Stephanie Hanor. Oakland: Mills College Art Museum, 2019."
-  #
-  # - id: "state_of_convergence"
-  #   src: /screenshots/_state_of_convergence.png
-  #   caption: "Exhibition catalogue | Mills College Art Museum"
-  #   full_caption: "*State of Convergence*, Oakland: Mills College Art Museum, 2020."
-  #
-  # - id: "tilt_west"
-  #   src: /screenshots/_tilt_west.png
-  #   caption: "Journal | Tilt West ([view](http://journal.tiltwest.org/vol1/))"
-  #   full_caption: "“Art and Language.” In *Art and Language*, by Nora Burnett Abrams, Noel Black, Angie Eng, Rick Griffith, Paul Miller, Juan Morales, Kelly Sears, Suzi Q. Smith, and Joel Swanson. Denver: Tilt West, 2020."
-  #
-  # - id: "silk_poems"
-  #   src: /screenshots/_silk_poems.png
-  #   caption: "Exhibition catalogue | The University of Hong Kong Museum and Art Gallery"
-  #   full_caption: "*Silk Poems: Jen Bervin*, by Jen Bervin, The University Museum and Art Gallery, The University of Hong Kong, 2019."
-  #
-  # - id: "ancient_ambers"
-  #   src: /screenshots/_ancient_ambers.png
-  #   caption: "Collection catalogue | Getty Publications"
-  #   full_caption: "*Ancient Carved Ambers in the J. Paul Getty Museum*, J. Paul Getty Museum."
-  #
-  # - id: "cva"
-  #   src: /screenshots/_cva.png
-  #   caption: "Corpus Vasorum Antiquorum | Getty Publications"
-  #   full_caption: "*Corpus Vasorum Antiquorum, Fascicule 10: Athenian Red-Figure Column- and Volute-Kraters*, by Despoina Tsiafakis, J. Paul Getty Museum, 2019."
-  #
-  # - id: "heritage_management"
-  #   src: /screenshots/_heritage_management.png
-  #   caption: "Research proceedings | Getty Publications"
-  #   full_caption: "Values in Heritage Management: Emerging Approaches and Research Directions, by Erica Avrami, et al, The Getty Conservation Institute, 2019."
-  #
-  # - id: "tour_toolkit"
-  #   src: /screenshots/_tour_toolkit.png
-  #   caption: "Informational Pamphlet | Minneapolis Institute of Art"
-  #   full_caption: "*Tour Toolkit: Developing an Inclusive Tour*, by Minneapolis Institue of Art, 2019."
-  #
-  # - id: "alcohols_empire"
-  #   src: /screenshots/_alcohols_empire.png
-  #   caption: "Online Exhibition | Minneapolis Institute of Art"
-  #   full_caption: "*Alcohol's Empire: Distilled Spirits in the 1700s Atlantic World*. Minneapolis Institute of Art, 2019."
-  #
-  # - id: "mozoomdar_at_sea"
-  #   src: /screenshots/_mozoomdar_at_sea.png
-  #   caption: "Student Research Project"
-  #   full_caption: "*Mozoomdar at Sea*, by Nick Tackes, 2018."
-  #
-  # - id: "humanizing_the_digital"
-  #   src: /screenshots/_humanizing_the_digital.png
-  #   caption: "Conference Proceedings | Ad Hoc Museum Collective"
-  #   full_caption: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, by Suse Anderson, et al, Ad Hoc Museum Collective, 2019."
-  #
-  # - id: "state_of_museum_dig"
-  #   src: /screenshots/_state_of_museum_dig.png
-  #   caption: "Graduate Essays | Ad Hoc Museum Collective"
-  #   full_caption: "*The State of Museum Digital Practice in 2019: A collection of graduate essays and responses*, by Suse Anderson, et al, Ad Hoc Museum Collective, 2019."
+  - id: "fault_lines"
+    src: /screenshots/_fault_lines.png
+    alt: "Screenshot of publication cover: a distorted and cropped photograph of a lower arm in front of a dark background"
+    type: Online Exhibition/Exhibition Catalogue
+    publisher: Mills College Art Museum
+    title_info: "*Fault Lines: 2020 Senior Thesis Exhibition*, by Sequoia Belk-Hurst, Téa Blatt, L.A. Bonet, De'Ana Brownfield, Carla Cardenas, Lexi Castillo, Sarah Frances, Slaone Gershov, Danielle La Fontaine, Thea Moerman, Raissa Palacios, Yana Sternberger-Moye, Ellis Teare, and Rowan Weir"
+    pub_date: 2020
+    url: https://mcam.mills.edu/publications/faultlines/index.html
+    customization_level:
+    github_user:
+    note:
+
+  - id: "in_plain_sight"
+    src: /screenshots/_in_plain_sight.png
+    alt: "Screenshot of publication cover: a wall of framed and hung artwork behind a sheet of partially opaque material"
+    type: Exhibition Catalogue
+    publisher: Mills College Art Museum
+    title_info: "*In Plain Sight: Kathryn Andrews, castaneda/reiman, Dario Robleto, Weston Teruya*, by Daniel Nevers, Joanna Fiduccia, Anne Lesley Selcer, and Stephanie Hanor"
+    pub_date: 2019
+    url: https://mcam.mills.edu/publications/inplainsight/index.html
+    customization_level:
+    github_user:
+    note:
+
+  - id: "state_of_convergence"
+    src: /screenshots/_state_of_convergence.png
+    alt: "Screenshot of publication cover: a fist punches through a sheet, onto which an image of mountains and trees is projected"
+    type: Online Exhibition/Exhibition Catalogue
+    publisher: Mills College Art Museum
+    title_info: "*State of Convergence*"
+    pub_date: 2020
+    url: https://mcam.mills.edu/publications/stateofconvergence/index.html
+    customization_level:
+    github_user:
+    note:
+
+  - id: "tilt_west"
+    src: /screenshots/_tilt_west.png
+    alt: "Screenshot of publication cover: a collage of scraps of text and brown, red, and green geometric shapes on a yellow background"
+    type: Journal
+    publisher: Tilt West
+    title_info: "*Tilt West Journal, vol. 1, Art and Language*, by Nora Burnett Abrams, Noel Black, Angie Eng, Rick Griffith, Paul Miller, Juan Morales, Kelly Sears, Suzi Q. Smith, and Joel Swanson"
+    pub_date: 2020-03
+    url: http://journal.tiltwest.org/vol1/
+    customization_level:
+    github_user:
+    note:
+
+  - id: "silk_poems"
+    src: /screenshots/_silk_poems.png
+    alt:
+    type: Exhibition Catalogue
+    publisher: Hong Kong University Museum of Art Gallery
+    title_info: "*Silk Poems*"
+    pub_date: 2019
+    url:
+    customization_level:
+    github_user:
+    note:
+
+  - id: "ancient_ambers"
+    src: /screenshots/_ancient_ambers.png
+    alt: "Screenshot of publication cover: a humanoid figurine carved out of dark red amber"
+    type: Collection Catalogue
+    publisher: Getty Publications
+    title_info: "*Ancient Carved Ambers in the J. Paul Getty Museum*, by Faya Causey"
+    pub_date: 2019
+    url: https://www.getty.edu/publications/ambers/
+    customization_level:
+    github_user:
+    note:
+
+  - id: "cva"
+    src: /screenshots/_cva.png
+    alt: "Screenshot of publication cover: black text in Latin and French on an off-white background"
+    type: Corpus Vasorum Antiquorum
+    publisher: Getty Publications
+    title_info: "*Corpus Vasorum Antiquorum, Fascicule 10: Athenian Red-Figure Column- and Volute-Kraters*, by Despoina Tsiafakis"
+    pub_date: 2019
+    url: https://www.getty.edu/publications/cva10/
+    customization_level:
+    github_user:
+    note:
+
+  - id: "heritage_management"
+    src: /screenshots/_heritage_management.png
+    alt: "Screenshot of publication cover: a patinated bronze sculpture covered in graffiti is being lifted off its pedestal with a crane as onlookers watch"
+    type: Research Proceedings
+    publisher: Getty Publications
+    title_info: "*Values in Heritage Management: Emerging Approaches and Research Directions*, by Erica Avrami, Susan MacDonald, Randall Madison, and David Myers"
+    pub_date: 2019
+    url: https://www.getty.edu/publications/heritagemanagement/
+    customization_level:
+    github_user:
+    note:
+
+  - id: "tour_toolkit"
+    src: /screenshots/_tour_toolkit.png
+    alt: "Screenshot of publication cover: a docent gives a tour to a group of schoolchildren inside a museum gallery"
+    type: Informational Pamphlet
+    publisher: Minneapolis Institute of Art
+    title_info: "*Tour Toolkit: Developing an Inclusive Tour*, by Minneapolis Institute of Art"
+    pub_date: 2019
+    url: https://artsmia.github.io/tour-toolkit/
+    customization_level:
+    github_user:
+    note:
+
+  - id: "alcohols_empire"
+    src: /screenshots/_alcohols_empire.png
+    alt: "Screenshot of publication cover: three cocktails sit on a stone table with sprigs of rosemary superimposed onto the photograph"
+    type: Digital Native Project
+    publisher: Minneapolis Institute of Art
+    title_info: "*Alcohol's Empire: Distilled Spirits in the 1700s Atlantic World*, edited by Nicole LaBouff and Emily Beck"
+    pub_date: 2019-02-04
+    url: https://artsmia.github.io/alcohols-empire/
+    customization_level:
+    github_user:
+    note:
+
+  - id: "mozoomdar_at_sea"
+    src: /screenshots/_mozoomdar_at_sea.png
+    alt: "Screenshot of publication cover: a watercolor and pencil image of the 1893 Columbian Exposition from a bird's eye perspective"
+    type: Research Project
+    publisher: Self-Published
+    title_info: "*Mozoomdar at Sea*, by Nick Tackes"
+    pub_date: 2018
+    url: https://mozoomdar-at-sea.netlify.app/
+    customization_level:
+    github_user:
+    note:
+
+ - id: "humanizing_the_digital"
+   src: /screenshots/_humanizing_the_digital.png
+   alt: "Screenshot of publication cover: black text on a white background with anthropomorphized computer file folders smattered across two wavy registers of qr-code"
+   type: Conference Proceedings
+   publisher: Ad Hoc Museum Collective
+   title_info: "*Humanizing the Digital: Unproceedings from the MCN 2018 Conference*, edited by Suse Anderson, Isabella Bruno, Hannah Hethmon, Seema Rao, Ed Rodley, and Rachel Ropeik"
+   pub_date: 2019
+   url: https://ad-hoc-museum-collective.github.io/humanizing-the-digital/
+   customization_level:
+   github_user:
+   note:
+
+ - id: "state_of_museum_dig"
+   src: /screenshots/_state_of_museum_dig.png
+   alt: "Screenshot of publication cover: myriad strands of twinkle lights hung in two horizontal registers across a large architectural space"
+   type: Graduate Student/Class Project
+   publisher: Ad Hoc Museum Collective
+   title_info: "*The State of Museum Digital Practice in 2019: A Collection of Graduate Essays and Responses*, by Suse Anderson, Cristin Guinan-Wiley, Jonathan Edelman, Rachel Rosenfeld, Mary McCulla, Sheridan Small, Cynthia Kurtz, Amy Pollard, Corrie Brady, Melissa Garcia, Caitlin Hepner, Sydney Thatcher, Laura Dickson, and Rebecca Brockette"
+   pub_date: 2019
+   url: https://ad-hoc-museum-collective.github.io/GWU-museum-digital-practice-2019/
+   customization_level:
+   github_user:
+   note:

--- a/layouts/shortcodes/q-showcase.html
+++ b/layouts/shortcodes/q-showcase.html
@@ -20,7 +20,7 @@
 {{ end }}
 <p><span class="publisher">{{ .publisher }}</span></p>
 <p>{{ .type }} | {{ dateFormat "2006" .pub_date }}</p>
-<p>Quire user: {{ with .github_user }}<a href="https://github.com/{{ . }}/" target="_blank">@{{ . }}</a>{{ end }}</p>
+{{ with .github_user }}{{ $len := len . }}<p>Quire user{{ if gt $len 1 }}s{{ end }}: {{ range . }}<a href="https://github.com/{{ . }}/" target="_blank">@{{ . }}</a> {{ end }}</p>{{ end }}
 <p>
 <span class="quire-citation expandable"><span class="quire-citation__button glossary-button" role="button" tabindex="0" aria-expanded="false">More <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg></span><span hidden class="quire-citation__content">{{ with .note }}{{ markdownify . }}<br />{{ end }}{{ with .customization_scale }}<br />Customization level: {{ . }}{{ end }}</span></span>
 <a href="{{ .url }}" target="_blank" class="view-link">View <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 5v2h6.59L4 18.59 5.41 20 17 8.41V15h2V5z"/></svg></a>

--- a/layouts/shortcodes/q-showcase.html
+++ b/layouts/shortcodes/q-showcase.html
@@ -22,7 +22,7 @@
 <p>{{ .type }} | {{ dateFormat "2006" .pub_date }}</p>
 {{ with .github_user }}{{ $len := len . }}<p>Quire user{{ if gt $len 1 }}s{{ end }}: {{ range . }}<a href="https://github.com/{{ . }}/" target="_blank">@{{ . }}</a> {{ end }}</p>{{ end }}
 <p>
-<span class="quire-citation expandable"><span class="quire-citation__button glossary-button" role="button" tabindex="0" aria-expanded="false">More <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg></span><span hidden class="quire-citation__content">{{ with .note }}{{ markdownify . }}<br />{{ end }}{{ with .customization_scale }}<br />Customization level: {{ . }}{{ end }}</span></span>
+<span class="quire-citation expandable"><span class="quire-citation__button glossary-button" role="button" tabindex="0" aria-expanded="false">More <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg></span><span hidden class="quire-citation__content">{{ with .note }}{{ markdownify . }}<br />{{ end }}{{ with .customization_level }}<br />Customization: {{ . | title }}{{ end }}</span></span>
 <a href="{{ .url }}" target="_blank" class="view-link">View <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 5v2h6.59L4 18.59 5.41 20 17 8.41V15h2V5z"/></svg></a>
 </p>
 </li>

--- a/layouts/shortcodes/q-showcase.html
+++ b/layouts/shortcodes/q-showcase.html
@@ -18,10 +18,12 @@
   </a>
 </figure>
 {{ end }}
-<p><span class="publisher">{{ .publisher }}</span> | {{ .type }}</p>
-<p><a href="{{ .url }}" target="_blank">{{ .title_info | markdownify }}</a></p>
-<p>{{ dateFormat "2006" .pub_date }}
-<span class="quire-citation expandable"><span class="quire-citation__button glossary-button" role="button" tabindex="0" aria-expanded="false">More <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg></span><span hidden class="quire-citation__content">{{ with .note }}{{ markdownify . }}<br />{{ end }}{{ with .github_user }}<br />Quire user: <a href="https://github.com/{{ . }}/" target="_blank">@{{ . }}</a>{{ end }}{{ with .customization_scale }}<br />Customization level: {{ . }}{{ end }}</span></span>
+<p><span class="publisher">{{ .publisher }}</span></p>
+<p>{{ .type }} | {{ dateFormat "2006" .pub_date }}</p>
+<p>Quire user: {{ with .github_user }}<a href="https://github.com/{{ . }}/" target="_blank">@{{ . }}</a>{{ end }}</p>
+<p>
+<span class="quire-citation expandable"><span class="quire-citation__button glossary-button" role="button" tabindex="0" aria-expanded="false">More <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg></span><span hidden class="quire-citation__content">{{ with .note }}{{ markdownify . }}<br />{{ end }}{{ with .customization_scale }}<br />Customization level: {{ . }}{{ end }}</span></span>
+<a href="{{ .url }}" target="_blank" class="view-link">View <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 5v2h6.59L4 18.59 5.41 20 17 8.41V15h2V5z"/></svg></a>
 </p>
 </li>
 {{ end }}

--- a/layouts/shortcodes/q-showcase.html
+++ b/layouts/shortcodes/q-showcase.html
@@ -1,0 +1,29 @@
+{{/*
+
+  Community showcase
+
+*/}}
+{{ $imgDir := "" }}
+{{ if isset .Site.Params "imagedir" }}
+  {{ $imgDir = .Site.Params.imageDir }}
+{{ end }}
+<ul class="showcase">
+{{ range sort .Site.Data.projects.project_list "pub_date" "desc" }}
+{{ if ne .id "" }}
+<li class="showcase-project">
+{{ if .src }}
+<figure>
+  <a href="{{ .url }}" target="_blank">
+    <img src="{{ printf "%s/%s" $imgDir .src | relURL }}" />
+  </a>
+</figure>
+{{ end }}
+<p><span class="publisher">{{ .publisher }}</span> | {{ .type }}</p>
+<p><a href="{{ .url }}" target="_blank">{{ .title_info | markdownify }}</a></p>
+<p>{{ dateFormat "2006" .pub_date }}
+<span class="quire-citation expandable"><span class="quire-citation__button glossary-button" role="button" tabindex="0" aria-expanded="false">More <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg></span><span hidden class="quire-citation__content">{{ with .note }}{{ markdownify . }}<br />{{ end }}{{ with .github_user }}<br />Quire user: <a href="https://github.com/{{ . }}/" target="_blank">@{{ . }}</a>{{ end }}{{ with .customization_scale }}<br />Customization level: {{ . }}{{ end }}</span></span>
+</p>
+</li>
+{{ end }}
+{{ end }}
+</ul>

--- a/layouts/shortcodes/q-showcase.html
+++ b/layouts/shortcodes/q-showcase.html
@@ -14,7 +14,7 @@
 {{ if .src }}
 <figure>
   <a href="{{ .url }}" target="_blank">
-    <img src="{{ printf "%s/%s" $imgDir .src | relURL }}" />
+    <img src="{{ printf "%s/%s" $imgDir .src | relURL }}"{{ with .alt }} alt="{{ . }}"{{ end }} />
   </a>
 </figure>
 {{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -628,6 +628,11 @@ class="slider-small", "slider-medium", "slider-large", or "slider-xlarge" */
   padding-top: 1rem;
   border-top: solid 1px var(--accent-color);
 }
+@media screen and (max-width: 500px) {
+  .quire-page__content .container .content ul.showcase {
+    grid-template-columns: 1fr;
+  }
+}
 .quire-page__content .container .content ul li.showcase-project::before {
   content: "";
   margin-left: 0;
@@ -665,6 +670,7 @@ class="slider-small", "slider-medium", "slider-large", or "slider-xlarge" */
 .quire-page__content .container .content ul li.showcase-project a.view-link svg {
   fill: var(--accent-color);
   vertical-align: text-top;
+  pointer-events: none;
 }
 .quire-page__content .container .content ul li.showcase-project figure {
   margin: 0;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -615,3 +615,55 @@ class="slider-small", "slider-medium", "slider-large", or "slider-xlarge" */
   display: block;
   margin-bottom: 1rem;
 }
+
+/* COMMUNITY SHOWCASE
+============================================================================= */
+.quire-page__content .container .content ul.showcase {
+  margin-left: 0;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 1.5rem;
+  margin: 2rem 0;
+  padding-top: 1rem;
+  border-top: solid 1px var(--accent-color);
+}
+.quire-page__content .container .content ul li.showcase-project::before {
+  content: "";
+  margin-left: 0;
+}
+.quire-page__content .container .content ul li.showcase-project {
+  margin-left: 0;
+  margin-top: 2rem;
+}
+.quire-page__content .container .content ul li.showcase-project p {
+  margin-bottom: 0;
+}
+.quire-page__content .container .content ul li.showcase-project span.publisher {
+  font-weight: bold;
+}
+.quire-page__content .container .content ul li.showcase-project .quire-citation {
+  float: right;
+  margin-right: 1rem;
+}
+.quire-page__content .container .content ul li.showcase-project .quire-citation__button {
+  color: var(--accent-color);
+  border-bottom-width: 0;
+  text-transform: uppercase;
+  font-size: .875rem;
+  letter-spacing: .5px;
+}
+.quire-page__content .container .content ul li.showcase-project .quire-citation__button svg {
+  fill: var(--accent-color);
+  vertical-align: text-top;
+}
+.quire-page__content .container .content ul li.showcase-project figure {
+  margin: 0;
+}
+.quire-page__content .container .content ul li.showcase-project figure a {
+  border-bottom-width: 0;
+}
+.quire-page__content .container .content ul li.showcase-project figure a:hover img {
+  transition: box-shadow 0.35s;
+  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.75);
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -642,18 +642,27 @@ class="slider-small", "slider-medium", "slider-large", or "slider-xlarge" */
 .quire-page__content .container .content ul li.showcase-project span.publisher {
   font-weight: bold;
 }
-.quire-page__content .container .content ul li.showcase-project .quire-citation {
-  float: right;
+.quire-page__content .container .content ul li.showcase-project .quire-citation,
+.quire-page__content .container .content ul li.showcase-project a.view-link {
+  /* float: right; */
   margin-right: 1rem;
 }
-.quire-page__content .container .content ul li.showcase-project .quire-citation__button {
+.quire-page__content .container .content ul li.showcase-project a.view-link {
+  padding: 6px 0;
+}
+.quire-page__content .container .content ul li.showcase-project .quire-citation__button,
+.quire-page__content .container .content ul li.showcase-project a.view-link {
   color: var(--accent-color);
   border-bottom-width: 0;
   text-transform: uppercase;
   font-size: .875rem;
   letter-spacing: .5px;
 }
-.quire-page__content .container .content ul li.showcase-project .quire-citation__button svg {
+.quire-page__content .container .content ul li.showcase-project a.view-link:hover {
+  border-bottom-width: 0 !important;
+}
+.quire-page__content .container .content ul li.showcase-project .quire-citation__button svg,
+.quire-page__content .container .content ul li.showcase-project a.view-link svg {
   fill: var(--accent-color);
   vertical-align: text-top;
 }


### PR DESCRIPTION
Here's my first pass at the community showcase. 

I've created a new YAML file (projects.yml) to collect info on each project, using the material we have in figures.yml as a seed for it, but I've only filled out three sample projects thus far. My goal here was to provide some basic info about the project, and then link to the project itself. I used our pop-up system to display some details as a way of not having to fill the page with a lot of text clutter.

