### PR TITLE
Section landings

### DIFF
--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -3,6 +3,7 @@ title: FAQ
 weight: 1200
 type: essay
 menu: false
+toc: false
 ---
 
 **Why is it called Quire?**

--- a/content/about/how-it-works.md
+++ b/content/about/how-it-works.md
@@ -3,6 +3,7 @@ title: How It Works
 weight: 1400
 type: essay
 menu: false
+toc: false
 ---
 
 At the heart of Quire is the [Quire CLI](https://github.com/gettypubs/quire-cli), or {{< q-def "command-line interface" >}}. It is used for creating, previewing, and outputting projects. (Read more in [Quire CLI Commands](/documentation/quire-cli/).)

--- a/content/about/open-source.md
+++ b/content/about/open-source.md
@@ -3,6 +3,7 @@ title: Why Open Source?
 weight: 1500
 type: essay
 menu: false
+toc: false
 ---
 
 Open source is a way of developing software where the source code is free and available for others to use and adapt. Open-source software relies on both transparency and an engaged community of users. The community works together to both use and contribute to the development of the software and its code.

--- a/content/about/roadmap.md
+++ b/content/about/roadmap.md
@@ -2,7 +2,6 @@
 title: Roadmap
 weight: 1700
 type: essay
-menu: false
 ---
 
 The Quire team at Getty continues work on Quire as a whole, including making improvements to the installation process, the overall architecture, and ongoing enhancements for web accessibility.

--- a/content/about/section.md
+++ b/content/about/section.md
@@ -1,0 +1,7 @@
+---
+title: About
+type: contents
+class: grid
+slug: .
+weight: 900
+---

--- a/content/community/code-of-conduct.md
+++ b/content/community/code-of-conduct.md
@@ -3,6 +3,7 @@ title: Code of Conduct
 weight: 2500
 type: essay
 menu: false
+toc: false
 ---
 
 ## QUIRE CODE OF CONDUCT

--- a/content/community/contributor-guidelines.md
+++ b/content/community/contributor-guidelines.md
@@ -3,6 +3,7 @@ title: Contributor Guidelines
 weight: 2501
 type: essay
 menu: false
+toc: false
 ---
 ## Introduction
 

--- a/content/community/section.md
+++ b/content/community/section.md
@@ -1,0 +1,7 @@
+---
+title: Community
+type: contents
+class: grid
+slug: .
+weight: 2100
+---

--- a/content/documentation/implementation.md
+++ b/content/documentation/implementation.md
@@ -2,6 +2,7 @@
 title: Implementation Considerations
 type: essay
 weight: 3999
+abstract: "Is Quire right for you and your project?"
 ---
 
 ## Technology Requirements

--- a/content/documentation/install-uninstall.md
+++ b/content/documentation/install-uninstall.md
@@ -2,6 +2,7 @@
 title: Install or Update
 weight: 4000
 type: essay
+abstract: "Get set up to use Quire on macOS, Window, or Linux"
 ---
 
 {{< q-class "box warning" >}}

--- a/content/documentation/section.md
+++ b/content/documentation/section.md
@@ -1,0 +1,7 @@
+---
+title: Documentation
+type: contents
+class: grid
+slug: .
+weight: 3998
+---

--- a/content/learn/section.md
+++ b/content/learn/section.md
@@ -1,0 +1,7 @@
+---
+title: Learn
+type: contents
+class: grid
+slug: .
+weight: 5900
+---

--- a/layouts/partials/contents-list.html
+++ b/layouts/partials/contents-list.html
@@ -5,7 +5,9 @@
 
   ALSO ADDS SUPPORT FOR AN external_url PARAMETER THAT CAN BE ADDED TO A PAGE
   TO CREATE AN EXTERNAL PAGE LINK IN THE MENU AND NAVIGATION BAR
-  
+
+  ADDS UP TO 80 CHARACTERS OF THE PAGE ABSTRACT TO THE GRID TABLE OF CONTENTS
+
 
   This partial generates a contents list. It is used in the publication menu
   and in the "contents" page type, but could be extended for further use. It
@@ -189,6 +191,7 @@
       <div class="card-content">
         <div class="title">
         {{- with .Page.Params.label }}{{ . }}{{ $.Site.Params.pageLabelDivider }}{{ end }}{{ if and .Page.Params.short_title (in .class "brief")}}{{ .Page.Params.short_title | markdownify }}{{ else if in .class "brief" }}{{ .Page.Title | markdownify }}{{ else }}{{ partial "page-title.html" . | markdownify }}{{ if .Page.Params.contributor }}<span class="contributor"> — {{ partial "contributor-list.html" (dict "range" .Page.Params.contributor "contributorType" "all" "listType" "string" "Site" .Site) }}</span>{{- end -}}{{- end -}}<span class="arrow remove-from-epub">&nbsp;{{- partial "icon.html" (dict "type" "arrow-forward" "description" "") -}}</span></div>
+        {{ with .Page.Params.abstract }}<div class="abstract">{{ . | markdownify | truncate 80 }}</div>{{ end }}
       </div>
     </div></a>
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -322,6 +322,19 @@ on the page and adjusts to different window widths */
 .quire-menu .page-item.active .quire__heading-links .main-heading a {
   color: var(--accent-color) !important;
 }
+.quire-menu .page-item.active > a,
+.quire-menu .section-item.active > a,
+.quire-menu .section-item > a {
+  font-weight: 700;
+}
+/* Even out row and column spacing in grid */
+.quire-contents-list.grid ul li a {
+  padding: 0;
+}
+.quire-contents-list.grid ul li .card {
+  margin: .625rem;
+}
+
 
 /* Make main section headings stand out visually */
 .quire-menu .section-item > .list-header,
@@ -723,4 +736,13 @@ dt code {
 /* Remove unneeded margin from definition lists */
 .quire-page__content .content dl {
   margin-left: 0;
+}
+/* Section landing pages */
+.quire-contents-list.grid ul li .card.no-image .card-content .title,
+.quire-contents-list.grid ul li .card.no-image .card-content .abstract  {
+  font-size: 1.5rem;
+  line-height: 1.4;
+}
+.quire-contents-list.grid ul li .card.no-image .card-content .abstract {
+  font-weight: 400;
 }


### PR DESCRIPTION
Adds landing pages for the main sections, which will display up to 80 characters of the `abstract` from each page. I put in a couple sample abstracts in the first two pages of the documentation section, but otherwise haven't add others.