### PR TITLE
Update publication slider for homepage

### DIFF
--- a/content/cover.md
+++ b/content/cover.md
@@ -20,7 +20,7 @@ slug: .
 
 </div>
 
-{{< q-showcase projects="thomas_rife, ancient_ambers, artists_studios_paris, bending_lines, fault_lines, state_of_convergence, tilt_west, heritage_management, cva" class="full-width-slider slider-md" >}}
+{{< q-showcase projects=" alcohols_empire, heritage_management, bending_lines, fault_lines, thomas_rife" class="full-width-slider slider-md" >}}
 
 <div class="action-button">
 

--- a/content/cover.md
+++ b/content/cover.md
@@ -20,7 +20,7 @@ slug: .
 
 </div>
 
-{{< q-showcase projects=" alcohols_empire, heritage_management, bending_lines, fault_lines, thomas_rife" class="full-width-slider slider-md" sort="false" >}}
+{{< q-showcase projects=" alcohols_empire, bending_lines, fault_lines, tilt_west, heritage_management" class="full-width-slider slider-md" sort="false" >}}
 
 <div class="action-button">
 

--- a/content/cover.md
+++ b/content/cover.md
@@ -20,7 +20,7 @@ slug: .
 
 </div>
 
-{{< q-showcase projects=" alcohols_empire, heritage_management, bending_lines, fault_lines, thomas_rife" class="full-width-slider slider-md" >}}
+{{< q-showcase projects=" alcohols_empire, heritage_management, bending_lines, fault_lines, thomas_rife" class="full-width-slider slider-md" sort="false" >}}
 
 <div class="action-button">
 

--- a/layouts/shortcodes/q-showcase.html
+++ b/layouts/shortcodes/q-showcase.html
@@ -10,20 +10,44 @@
   Use an optional "class" parameter to add a custom class to
   <ul class="showcase"> for styling.
 
+  Use an optional "sort" parameter with a value of "false" to sort in the order
+  the projects were listed in the shortcode, rather than by the default pub_date
+
 */}}
-{{- $imgDir := "" -}}
-{{- if isset .Site.Params "imagedir" -}}
-  {{- $imgDir = .Site.Params.imageDir -}}
-{{- end -}}
 
 {{- $projects := "" -}}
 {{- if .Get "projects" -}}
 {{- $projects = .Get "projects" -}}
 {{- end -}}
 
-<ul class="showcase{{ with .Get "class" }} {{ . }}{{ end }}">
-{{ range sort .Site.Data.projects.project_list "pub_date" "desc" }}
-{{ if or (eq $projects "") (in $projects .id) }}
+{{- $sort := "true" -}}
+{{- with .Get "sort" -}}
+{{- $sort = . -}}
+{{- end -}}
+
+{{- if eq $sort "false" -}}
+  <ul class="showcase{{ with .Get "class" }} {{ . }}{{ end }}">
+  {{- range (split $projects ",") -}}
+  {{- $id := . -}}
+  {{- range $.Site.Data.projects.project_list -}}
+  {{- if in $id .id -}}
+    {{ template "showcase-item" . }}
+  {{- end -}}
+  {{- end -}}
+  {{- end -}}
+  </ul>
+{{- else -}}
+  <ul class="showcase{{ with .Get "class" }} {{ . }}{{ end }}">
+  {{- range sort .Site.Data.projects.project_list "pub_date" "desc" -}}
+  {{- if or (eq $projects "") (in $projects .id) -}}
+    {{ template "showcase-item" . }}
+  {{- end -}}
+  {{- end -}}
+  </ul>
+{{- end -}}
+
+{{- define "showcase-item" -}}
+{{- $imgDir := "img" -}}
 <li class="showcase-project">
 {{ if .src }}
 <figure>
@@ -44,6 +68,4 @@
 {{ end }}
 </p>
 </li>
-{{ end }}
-{{ end }}
-</ul>
+{{- end -}}


### PR DESCRIPTION
This is in response to PR #301 

Amanda wasn't ready for us to post 50 x 50 yet, but I'll make a note to check back in with her. 

I trimmed it down to 5 publications. 
I removed the older Mills pub, Ancient Ambers, CVA, and Tilt West.
I added Alcohol's Empire. 

Unfortunately, I don't seem to be able to change the ordering. Looks like it's sticking to chronological order, and I would prefer Thomas Rife not be the first thing people see. Any ideas?