### PR TITLE
Contributing and Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,4 @@
----
-title: Code of Conduct
-weight: 2500
-type: essay
-menu: false
-toc: false
----
-
-## QUIRE CODE OF CONDUCT
+# Quire Code of Conduct
 
 Version 1.0 (dated September 2, 2020)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,9 +6,9 @@ Version 1.0 (dated September 2, 2020)
 
 Our Code of Conduct provides guidance to help foster friendly and respectful interactions and outlines the consequences for anyone found violating this code. Our Code of Conduct applies across all Quire-related communication platforms including the GitHub Discussions forum, GitHub repositories, the Quire email list, and any private correspondence. It also applies to remote and in-person meetings, events, conferences, and any instances in which a community member represents Quire out in the world. We strive to maintain a positive, collaborative, and enriching experience for our community. To help us reach this goal, we ask that all community members adhere to the following guidelines for participation.
 
-If you believe that someone is violating the Quire Code of Conduct, we ask that you please report this behavior immediately by emailing quire@getty.edu. For more information, please see our **Reporting Guidelines** below.
+If you believe that someone is violating the Quire Code of Conduct, we ask that you please report this behavior immediately by emailing [quire@getty.edu](mailto:quire@getty.edu). For more information, please see our [Reporting Guidelines](#reporting-guidelines) below.
 
-### QUIRE GUIDELINES
+## QUIRE GUIDELINES
 
 - **We are friendly and patient.**
 
@@ -22,8 +22,7 @@ If you believe that someone is violating the Quire Code of Conduct, we ask that 
 
 - **We try to understand why we disagree**: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of our community comes from its diversity. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err, and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
-
-### ANTI-HARASSMENT
+## ANTI-HARASSMENT
 
 The Quire community is dedicated to providing a harassment-free collaboration experience for everyone regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, faith, or anything else. We do not tolerate harassment of community members in any form. Sexual or discriminatory language and imagery is not appropriate at any time.
 
@@ -38,10 +37,9 @@ Harassment includes, but is not limited to:
 - Advocating for, or encouraging, any of the above behavior
 - Repeated harassment of others. In general, if someone asks you to stop, then stop
 
+## REPORTING GUIDELINES
 
-### REPORTING GUIDELINES
-
-If you are being harassed or see someone participating in harassment of any form, we ask that you please report this behavior immediately by emailing quire@getty.edu. Please include the following information:
+If you are being harassed or see someone participating in harassment of any form, we ask that you please report this behavior immediately by emailing [quire@getty.edu](mailto:quire@getty.edu). Please include the following information:
 
 - Your contact info (so we can get in touch with you if we need to follow up).
 - Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
@@ -51,15 +49,14 @@ If you are being harassed or see someone participating in harassment of any form
 - If you believe this incident is or may be ongoing.
 - Any other information you believe we should have.
 
-
-### CONSEQUENCES FOR CODE OF CONDUCT VIOLATIONS
+## CONSEQUENCES FOR CODE OF CONDUCT VIOLATIONS
 
 If a participant engages in any behavior violating this Code of Conduct, the core members of this community may take any action they deem appropriate, including warning the offender, exclusion from any interaction, loss of all rights in this community, and expulsion from the community. Community members asked, by anyone, to stop any harassing behavior are expected to comply immediately.
 
-### FOR QUESTIONS OR FEEDBACK
+## FOR QUESTIONS OR FEEDBACK
 
-If you have questions or feedback on this Code of Conduct please feel free to reach out to us at any time at quire@getty.edu.
+If you have questions or feedback on this Code of Conduct please feel free to reach out to us at any time at [quire@getty.edu](quire@getty.edu).
 
-### ACKNOWLEDGEMENTS
+## ACKNOWLEDGEMENTS
 
 The Quire Code of Conduct has been modeled on the Code of Conduct policies from [Hoodie](http://hood.ie/code-of-conduct/), [IIIF](https://iiif.io/event/conduct/), [Django](https://www.djangoproject.com/conduct/), and [Arches](https://www.archesproject.org/code-of-conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ If there’s a section you think it missing or could be improved, we’d love fo
 
 - [Propose a new section or edit](https://github.com/gettypubs/quire/issues/new)
 - [Find an existing issue](https://github.com/gettypubs/quire/issues?q=is%3Aissue+is%3Aopen+label%3Aquire-website)
-- Read the Quire Documentation Style Guide — *in progress*
+- [Read the Quire Documentation Style Guide](https://github.com/gettypubs/quire/wiki/Quire-Documentation-Style-Guide)
 
 ### Translate the Documentation
 
@@ -101,7 +101,7 @@ If you’re interested in it being added to the core Quire starter theme, keep i
 Even if you plan on developing your custom theme/feature independently and offering it to the Quire community as an add on, we highly recommend posting about it on the Quire issue tracker. This lets people know what you’re working on, gives them a chance to offer to help, and can bring you valuable feedback and exposure for your work.
 
 - [View the current roadmap]((https://gettypubs.github.io/quire/documentation/))
-- Read the Quire Technical Style Guide — *in progress*
+- [Read the Quire Technical Style Guide](https://github.com/gettypubs/quire/wiki/Quire-Technical-Style-Guide)
 - [Post your feature idea](https://github.com/gettypubs/quire/issues/new)
 
 Quire is very extensible and we’re eager to see more development work come from you as you create and customize your own publications in ways that can then be shared back. Quire is in the early stages of defining how this kind of contribution will work, please don’t hesitate to [email us](mailto:quire@getty.edu) with your questions or ideas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,15 @@ Striving toward becoming a fully open-source project, we encourage contributions
 
 There are [many ways to contribute](#identify-a-contribution-to-make) including fixing bugs, and improving the documentation, to creating a new feature or theme.
 
-The following guidelines focus on contributions to one of our four code repositories (including the repository for the Quire website and documentation). Please read through them carefully. Our goal is to make the process as effective and transparent as possible, and to ensure that your every contribution can become part of Quire. Thank you for taking the time.
+The following guidelines focus on contributions to one of [our four code repositories](#quire-code-repositories) (including the repository for the Quire website and documentation). Please read through them carefully. Our goal is to make the process as effective and transparent as possible, and to ensure that your every contribution can become part of Quire. Thank you for taking the time.
 
-Read about [even more ways of getting involved](https://gettypubs.github.io/community/join-us/) beyond our code and documentation repositories, including participating in our forum, becoming a Quire ambassador, and attending or leading workshops, events, and training sessions.
+There are [even more ways of getting involved](https://gettypubs.github.io/community/join-us/) beyond our code and documentation repositories listed on the Quire website. They include participating in our forum, becoming a Quire ambassador, and attending or leading workshops, events, and training sessions.
 
 🗣**CALLING ALL FIRST-TIMERS!** — We can’t stress enough that Quire is open to contributors at all levels. That could mean making a modest fix to some Quire CSS styles or JavaScript, or copyediting one of our documentation pages. Here are a few resources especially for you:
 
-- Quire’s current [“good first issue”](https://github.com/gettypubs/quire/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-- Quire video on “Making Your First Contribution” —TK
-- [First Timers Only](http://www.firsttimersonly.com/)
+- Find the [“good first issues”](https://github.com/gettypubs/quire/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) tagged in our issue tracker
+- Read the Quire guide to Making Your First Contribution — *in progress*
+- Learn more about contributing to open source at [First Timers Only](http://www.firsttimersonly.com/)
 
 ## Important Resources
 
@@ -70,7 +70,7 @@ If there’s a section you think it missing or could be improved, we’d love fo
 
 - [Propose a new section or edit](https://github.com/gettypubs/quire/issues/new)
 - [Find an existing issue](https://github.com/gettypubs/quire/issues?q=is%3Aissue+is%3Aopen+label%3Aquire-website)
-- Read the Quire Documentation Style Guide -- TK
+- Read the Quire Documentation Style Guide — *in progress*
 
 ### Translate the Documentation
 
@@ -101,7 +101,7 @@ If you’re interested in it being added to the core Quire starter theme, keep i
 Even if you plan on developing your custom theme/feature independently and offering it to the Quire community as an add on, we highly recommend posting about it on the Quire issue tracker. This lets people know what you’re working on, gives them a chance to offer to help, and can bring you valuable feedback and exposure for your work.
 
 - [View the current roadmap]((https://gettypubs.github.io/quire/documentation/))
-- Read the Quire Technical Style Guide -- TK
+- Read the Quire Technical Style Guide — *in progress*
 - [Post your feature idea](https://github.com/gettypubs/quire/issues/new)
 
 Quire is very extensible and we’re eager to see more development work come from you as you create and customize your own publications in ways that can then be shared back. Quire is in the early stages of defining how this kind of contribution will work, please don’t hesitate to [email us](mailto:quire@getty.edu) with your questions or ideas.
@@ -146,4 +146,4 @@ Learn more in the *Open Source Guide*’s [“How to Contribute to Open Source�
 
 ---
 
-**At this point, you're ready to contribute! Feel free to [ask for help](mailto:quire@getty.edu), remember [everyone’s a beginner at first](https://firstpr.me/). And thank you again for your interest in making Quire a better tool for all!** 🦄
+**At this point, we hope you feel ready to contribute! But don’t hesitate to [ask for help or clarification](mailto:quire@getty.edu), everyone’s a beginner at first. And thank you again for your interest in making Quire a better tool for all!** 🦄

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,104 @@
-# Contributor Guidelines
+# Quire Contributor Guidelines
 
-## Introduction
+**Thank you for your interest in contributing to Quire!**
 
-Thank you for your interest in contributing to Quire! The following Contributor Guidelines will ensure streamlined and effective communication, and will help the Quire team develop and improve Quire in a timely and efficient manner. Thank you for taking the time to read through the following considerations.
-
-### Useful Contributions
-
-As an open-source project we encourage contributions from our community members. No matter what level of experience you have, we welcome all contributions, big and small.
+Striving toward becoming a fully open-source project, we encourage contributions from our community members. No matter what level of experience you have, we welcome all contributions, big and small.
 
 There are many ways to contribute from adding to the code, submitting bug reports and improving the documentation to participating in our forum, becoming a Quire ambassador, and attending or leading workshops, events, and training sessions.
 
-<div class="action-button">
+The following Contributor Guidelines will ensure streamlined and effective communication, and will help the Quire team develop and improve Quire in a timely and efficient manner. Thank you for taking the time to read through the following considerations.
 
-[Get Involved](/community/join-us/)
-</div>
+**CALLING ALL FIRST-TIMERS!** -- TK
 
-### Important Things to Remember
+## Important Resources
 
-Always check the **[documentation](https://quire/getty.edu/documentation)** first.
+- [Issue Tracking](https://github.com/gettypubs/quire/issues/)
+- [Documentation](https://gettypubs.github.io/quire/documentation/)
+- [Forum](https://gettypubs.github.io/quire/community/forum/)
 
-Refer to the **[forum](/community/forum/)** for support, to ask and answer questions, and for general information.
+Contact us at [quire@getty.edu](mailto:quire@getty.edu)
 
-For bugs, please refer to **[GitHub Issues](https://github.com/gettypubs/quire/issues)**.
+**All are welcome.** As an open-source community, Quire is committed to providing a safe, welcoming, transparent, and inclusive environment for all our community members and those wishing to become involved. Please see our **[Code of Conduct](https://github.com/gettypubs/quire/blob/master/CODE_OF_CONDUCT.md)** for more on the expecations and protections for our community members.
 
-More TK
+## Quire Code Repositories
 
-### Ground Rules
+There are four repositories hosted on GitHub that make up Quire, which is currently in closed beta. Please [sign-up for access](https://forms.gle/m1fgZu5BHKhddMrW7).
 
-Always be friendly and patient. Be welcoming, considerate, and respectful. Be careful with the words you choose. Try to understand why we disagree. Do not make offensive comments, insults, or jokes. Do not deliberately threaten or intimidate. Do not use sexually explicit or violent language or images. Harassment will not be tolerated.  For more guidelines on appropriate behavior, please see our [Code of Conduct](https://quire/getty.edu/community/code-of-conduct).
+- [**quire-cli**](https://github.com/gettypubs/quire-cli): The command-line interface for Quire. Written in JavaScript, it is the heart of Quire, chaining together its various parts into unified commands.
+- [**quire-starter-theme**](https://github.com/gettypubs/quire-starter-theme): The theme that is included when starting a new Quire project with the `quire new` command. It is designed to broadly cover a full range of use-cases and to demonstrate the range of Quire content model. The theme is where all the page templates and layout logic exist. Quire is built on [Hugo](https://gohugo.io/).
+- [**quire-starter**](https://github.com/gettypubs/quire-starter): A starter content repository used as placeholder content when starting a new Quire project with the `quire new` command. It comes with some pre-defined example content and pages with which to get started.
+- [**quire**](https://github.com/gettypubs/quire): The Quire website, and the central location for issues and discussion forum posts.
+
+## Identify a Contribution to Make
+
+**The first step to any contribution** is to post or comment [on our issue tracker](https://github.com/gettypubs/quire/issues/) about it.
+
+Find the existing relevant issue, or if it’s a new suggestion or bug, create an issue for it. In your comments, briefly describe your proposed solution and say whether you may need help with any aspect of it. This approach has several advantages:
+
+- Lets people know you’re working on it
+- Gives the maintainers and community a chance to give feedback before you do any work
+- Helps to ensure your contribution will be accepted and successfully merged in
+
+All Quire issues should be posted to, and are tracked through, our central https://github.com/gettypubs/quire repository. Please refer there even if the issue is more specifically about one of Quire’s other repositories.
+
+**The second step to any contribution**, once you’ve identified what you’d like to contribute, is to start work on it and prepare to submit. Read our [submission guidelines](#submit-your-contribution) below.
+
+### Fix a Bug
+
+Whether you’ve found a new bug and a way to fix it, or would like to help us to tackle bugs that have already been identified, thank you!
+
+- [Post a new bug](https://github.com/gettypubs/quire/issues/new)
+- [Find an existing bug to work on](https://github.com/gettypubs/quire/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+
+### Improve the Documentation
+
+The Quire documentation is continuously being updated for clarity and completeness, but it’s not always easy to keep up with the pace of Quire’s development!
+
+If there’s a section you think it missing or could be improved, we’d love for your help. And the documentation is itself a Quire site, so it should be familiar to work in.
+
+- [Propose a new section or edit](https://github.com/gettypubs/quire/issues/new)
+- [Find an existing issue](https://github.com/gettypubs/quire/issues)
+- Read the Quire Documentation Style Guide -- TK
+
+### Translate the Documentation
+
+The Quire community is global and we hope to be able to continue to expand access to Quire, including to non-English speakers. Though we haven’t yet done any translation work on any of the documentation or materials, if that’s something you’re interested in doing, we’d love to talk to you.
+
+- [Volunteer to do some translation](https://github.com/gettypubs/quire/issues/new)
+
+### Write an Article
+
+We’re always interested in adding articles about specific aspects of working in Quire to our Learn knowledge base. Maybe you have some tips on modifying shortcodes, or styling is CSS in the custom.css. Chances are the community would love to read about it.
+
+- [Share your article idea](https://github.com/gettypubs/quire/issues/new)
+
+*And if you need help getting your article converted from it’s current format into Markdown and onto the Quire website, we’re happy to guide you through that process.*
+
+### Develop a New Feature or Theme
+
+In Quire, themes contain all of a Quire publication’s key features in templates, shortcodes, styles and scripts. Themes can be complete packages of base styles and features, like [Quire’s starter theme](https://github.com/gettypubs/quire-starter-theme), or can be smaller packages of just one or more features to be layered on top of a base theme.
+
+So, when creating a new feature of some kind, you’ll be looking to do so either within the Quire starter theme, or as a standalone theme, which other Quire users can add to their projects as they’d like.
+
+If you’re interested in it being added to the core Quire starter theme, keep in mind some of the questions the maintainers and community will be asking of it:
+
+- Does this feature add something new that would be useful to a broad section of Quire’s user base?
+- Does this feature positively effect Quire’s primary tenants of producing publications optimized for discoverability, longevity, beauty and accessibility?
+- Does this feature integrate seamlessly in Quire’s current architecture and will it be reasonable to maintain?
+
+Even if you plan on developing your custom theme/feature independently and offering it to the Quire community as an add on, we highly recommend posting about it on the Quire issue tracker. This lets people know what you’re working on, gives them a chance to offer to help, and can bring you valuable feedback and exposure for your work.
+
+- [View the current roadmap]((https://gettypubs.github.io/quire/documentation/))
+- Read the Quire Technical Style Guide -- TK
+- [Post your feature idea](https://github.com/gettypubs/quire/issues/new)
+
+Quire is very extensible and we’re eager to see more development work come from you, our community, as you create and customize your own publications in ways that can then be shared back. Quire is in the early stages of defining what this kind of contribution will work, please don’t hesitate to [email us](mailto:quire@getty.edu) with your questions or ideas.
+
+## Submit Your Contribution
+
+Once you’ve identified your contribution on our issues board (either by submitting a new issue, or commenting on an existing one), you’ll next work on it and prepare to submit it to us as a pull request.
+
+
 
 -----------
 
@@ -60,102 +131,3 @@ At this point, you're ready to make your changes! Feel free to ask for help; eve
 
 If a maintainer asks you to "rebase" your PR, they're saying that a lot of code has changed, and that you need to update your branch so it's easier to merge.
 
-### Getting started (**Text below is placeholder text**)
-
-Give them a quick walkthrough of how to submit a contribution. How you write this is up to you, but some things you may want to include:
-
-Let them know if they need to sign a CLA, agree to a DCO, or get any other legal stuff out of the way
-If tests are required for contributions, let them know, and explain how to run the tests
-If you use anything other than GitHub to manage issues (ex. JIRA or Trac), let them know which tools they’ll need to contribute
-For something that is bigger than a one or two line fix:
-
-Create your own fork of the code
-Do the changes in your fork
-If you like the change and think the project could use it: * Be sure you have followed the code style for the project. * Sign the Contributor License Agreement, CLA, with the jQuery Foundation. * Note the jQuery Foundation Code of Conduct. * Send a pull request indicating that you have a CLA on file.
-[source: Requirejs] Need more inspiration? [1] Active Admin [2] Node.js [3] Ember.js
-
-If you have a different process for small or "obvious" fixes, let them know.
-Small contributions such as fixing spelling errors, where the content is small enough to not be considered intellectual property, can be submitted by a contributor as a patch, without a CLA.
-
-As a rule of thumb, changes are obvious fixes if they do not introduce any new functionality or creative thinking. As long as the change does not affect functionality, some likely examples include the following:
-
-Spelling / grammar fixes
-Typo correction, white space and formatting changes
-Comment clean up
-Bug fixes that change default return values or error codes stored in constants
-Adding logging messages or debugging output
-Changes to ‘metadata’ files like Gemfile, .gitignore, build scripts, etc.
-Moving source files from one directory or package to another
-[source: Chef] Need more inspiration? [1] Puppet
-
-How to report a bug
-Explain security disclosures first!
-At bare minimum, include this sentence:
-
-If you find a security vulnerability, do NOT open an issue. Email XXXX instead.
-
-If you don’t want to use your personal contact information, set up a “security@” email address. Larger projects might have more formal processes for disclosing security, including encrypted communication. (Disclosure: I am not a security expert.)
-
-Any security issues should be submitted directly to security@travis-ci.org In order to determine whether you are dealing with a security issue, ask yourself these two questions:
-
-Can I access something that's not mine, or something I shouldn't have access to?
-Can I disable something for other people?
-If the answer to either of those two questions are "yes", then you're probably dealing with a security issue. Note that even if you answer "no" to both questions, you may still be dealing with a security issue, so if you're unsure, just email us at security@travis-ci.org.
-
-[source: Travis CI] Need more inspiration? [1] Celery [2] Express.js
-
-Tell your contributors how to file a bug report.
-You can even include a template so people can just copy-paste (again, less work for you).
-
-When filing an issue, make sure to answer these five questions:
-
-What version of Go are you using (go version)?
-What operating system and processor architecture are you using?
-What did you do?
-What did you expect to see?
-What did you see instead? General questions should go to the golang-nuts mailing list instead of the issue tracker. The gophers there will answer or ask you to file an issue if you've tripped over a bug.
-[source: Go] Need more inspiration? [1] Celery [2] Atom (includes template)
-
-How to suggest a feature or enhancement
-If you have a particular roadmap, goals, or philosophy for development, share it here.
-This information will give contributors context before they make suggestions that may not align with the project’s needs.
-
-The Express philosophy is to provide small, robust tooling for HTTP servers, making it a great solution for single page applications, web sites, hybrids, or public HTTP APIs.
-
-Express does not force you to use any specific ORM or template engine. With support for over 14 template engines via Consolidate.js, you can quickly craft your perfect framework.
-
-[source: Express] Need more inspiration? Active Admin
-
-Explain your desired process for suggesting a feature.
-If there is back-and-forth or signoff required, say so. Ask them to scope the feature, thinking through why it’s needed and how it might work.
-
-If you find yourself wishing for a feature that doesn't exist in Elasticsearch, you are probably not alone. There are bound to be others out there with similar needs. Many of the features that Elasticsearch has today have been added because our users saw the need. Open an issue on our issues list on GitHub which describes the feature you would like to see, why you need it, and how it should work.
-
-[source: Elasticsearch] Need more inspiration? [1] Hoodie [2] Ember.js
-
-Code review process
-Explain how a contribution gets accepted after it’s been submitted.
-Who reviews it? Who needs to sign off before it’s accepted? When should a contributor expect to hear from you? How can contributors get commit access, if at all?
-
-The core team looks at Pull Requests on a regular basis in a weekly triage meeting that we hold in a public Google Hangout. The hangout is announced in the weekly status updates that are sent to the puppet-dev list. Notes are posted to the Puppet Community community-triage repo and include a link to a YouTube recording of the hangout. After feedback has been given we expect responses within two weeks. After two weeks we may close the pull request if it isn't showing any activity.
-
-[source: Puppet] Need more inspiration? [1] Meteor [2] Express.js
-
-Community
-If there are other channels you use besides GitHub to discuss contributions, mention them here. You can also list the author, maintainers, and/or contributors here, or set expectations for response time.
-
-You can chat with the core team on https://gitter.im/cucumber/cucumber. We try to have office hours on Fridays.
-
-[source: cucumber-ruby] Need more inspiration? [1] Chef [2] Cookiecutter
-
-BONUS: Code, commit message and labeling conventions
-These sections are not necessary, but can help streamline the contributions you receive.
-
-Explain your preferred style for code, if you have any.
-Need inspiration? [1] Requirejs [2] Elasticsearch
-
-Explain if you use any commit message conventions.
-Need inspiration? [1] Angular [2] Node.js
-
-Explain if you use any labeling conventions for issues.
-Need inspiration? [1] StandardIssueLabels [2] Atom

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,5 @@
----
-title: Contributor Guidelines
-weight: 2501
-type: essay
-menu: false
-toc: false
----
+# Contributor Guidelines
+
 ## Introduction
 
 Thank you for your interest in contributing to Quire! The following Contributor Guidelines will ensure streamlined and effective communication, and will help the Quire team develop and improve Quire in a timely and efficient manner. Thank you for taking the time to read through the following considerations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,29 @@
 
 Striving toward becoming a fully open-source project, we encourage contributions from our community members. No matter what level of experience you have, we welcome all contributions, big and small.
 
-There are many ways to contribute from adding to the code, submitting bug reports and improving the documentation to participating in our forum, becoming a Quire ambassador, and attending or leading workshops, events, and training sessions.
+There are [many ways to contribute](#identify-a-contribution-to-make) including fixing bugs, and improving the documentation, to creating a new feature or theme.
 
-The following Contributor Guidelines will ensure streamlined and effective communication, and will help the Quire team develop and improve Quire in a timely and efficient manner. Thank you for taking the time to read through the following considerations.
+The following guidelines focus on contributions to one of our four code repositories (including the repository for the Quire website and documentation). Please read through them carefully. Our goal is to make the process as effective and transparent as possible, and to ensure that your every contribution can become part of Quire. Thank you for taking the time.
 
-**CALLING ALL FIRST-TIMERS!** -- TK
+Read about [even more ways of getting involved](https://gettypubs.github.io/community/join-us/) beyond our code and documentation repositories, including participating in our forum, becoming a Quire ambassador, and attending or leading workshops, events, and training sessions.
+
+🗣**CALLING ALL FIRST-TIMERS!** — We can’t stress enough that Quire is open to contributors at all levels. That could mean making a modest fix to some Quire CSS styles or JavaScript, or copyediting one of our documentation pages. Here are a few resources especially for you:
+
+- Quire’s current [“good first issue”](https://github.com/gettypubs/quire/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+- Quire video on “Making Your First Contribution” —TK
+- [First Timers Only](http://www.firsttimersonly.com/)
 
 ## Important Resources
 
 - [Issue Tracking](https://github.com/gettypubs/quire/issues/)
 - [Documentation](https://gettypubs.github.io/quire/documentation/)
 - [Forum](https://gettypubs.github.io/quire/community/forum/)
+
+**Quire Core Team:**
+
+Greg Albers ([@geealbers](https://github.com/geealbers)) and David Newbury ([@workergnome](https://github.com/workergnome)), product managers<br />
+Matthew Hrudka ([@mphstudios](https://github.com/mphstudios)), lead maintainer<br />
+Erin Cecele Dunigan ([@Erin-Cecele](https://github.com/Erin-Cecele)), community manager<br />
 
 Contact us at [quire@getty.edu](mailto:quire@getty.edu)
 
@@ -31,17 +43,17 @@ There are four repositories hosted on GitHub that make up Quire, which is curren
 
 ## Identify a Contribution to Make
 
-**The first step to any contribution** is to post or comment [on our issue tracker](https://github.com/gettypubs/quire/issues/) about it.
+**The first step to any contribution** is to post a new issue or comment on an existing issue [on our issue tracker](https://github.com/gettypubs/quire/issues/).
 
 Find the existing relevant issue, or if it’s a new suggestion or bug, create an issue for it. In your comments, briefly describe your proposed solution and say whether you may need help with any aspect of it. This approach has several advantages:
 
 - Lets people know you’re working on it
-- Gives the maintainers and community a chance to give feedback before you do any work
+- Gives the core team and the community a chance to give feedback before you do any work
 - Helps to ensure your contribution will be accepted and successfully merged in
 
-All Quire issues should be posted to, and are tracked through, our central https://github.com/gettypubs/quire repository. Please refer there even if the issue is more specifically about one of Quire’s other repositories.
+All Quire issues should be posted to, and are tracked through, our [central Quire project repository](https://github.com/gettypubs/quire). Please refer there even if the issue is more specifically about one of Quire’s other repositories.
 
-**The second step to any contribution**, once you’ve identified what you’d like to contribute, is to start work on it and prepare to submit. Read our [submission guidelines](#submit-your-contribution) below.
+**The second step to any contribution**, once you’ve identified what you’d like to contribute, is to start work on it and prepare to submit. Read our [submission guide](#submit-your-contribution) below.
 
 ### Fix a Bug
 
@@ -57,7 +69,7 @@ The Quire documentation is continuously being updated for clarity and completene
 If there’s a section you think it missing or could be improved, we’d love for your help. And the documentation is itself a Quire site, so it should be familiar to work in.
 
 - [Propose a new section or edit](https://github.com/gettypubs/quire/issues/new)
-- [Find an existing issue](https://github.com/gettypubs/quire/issues)
+- [Find an existing issue](https://github.com/gettypubs/quire/issues?q=is%3Aissue+is%3Aopen+label%3Aquire-website)
 - Read the Quire Documentation Style Guide -- TK
 
 ### Translate the Documentation
@@ -80,7 +92,7 @@ In Quire, themes contain all of a Quire publication’s key features in template
 
 So, when creating a new feature of some kind, you’ll be looking to do so either within the Quire starter theme, or as a standalone theme, which other Quire users can add to their projects as they’d like.
 
-If you’re interested in it being added to the core Quire starter theme, keep in mind some of the questions the maintainers and community will be asking of it:
+If you’re interested in it being added to the core Quire starter theme, keep in mind some of the questions the core team and the community will be asking:
 
 - Does this feature add something new that would be useful to a broad section of Quire’s user base?
 - Does this feature positively effect Quire’s primary tenants of producing publications optimized for discoverability, longevity, beauty and accessibility?
@@ -92,42 +104,46 @@ Even if you plan on developing your custom theme/feature independently and offer
 - Read the Quire Technical Style Guide -- TK
 - [Post your feature idea](https://github.com/gettypubs/quire/issues/new)
 
-Quire is very extensible and we’re eager to see more development work come from you, our community, as you create and customize your own publications in ways that can then be shared back. Quire is in the early stages of defining what this kind of contribution will work, please don’t hesitate to [email us](mailto:quire@getty.edu) with your questions or ideas.
+Quire is very extensible and we’re eager to see more development work come from you as you create and customize your own publications in ways that can then be shared back. Quire is in the early stages of defining how this kind of contribution will work, please don’t hesitate to [email us](mailto:quire@getty.edu) with your questions or ideas.
 
 ## Submit Your Contribution
 
-Once you’ve identified your contribution on our issues board (either by submitting a new issue, or commenting on an existing one), you’ll next work on it and prepare to submit it to us as a pull request.
+*We manage Quire through GitHub. If you are new to GitHub, we recommend [GitHub Docs](https://docs.github.com/en/free-pro-team@latest/github) to learn by topic, and for a broad overview, [GitHub Guides](https://guides.github.com/) and Coding Train’s videso series [Git and Github for Poets](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6ZF9C0YMKuns9sLDzK6zoiV). GitHub can be accessed through the command line or [GitHub Desktop](https://desktop.github.com/).*
 
+Once you’ve identified your contribution on our GitHub [issues board](https://github.com/gettypubs/quire/issues) (either by submitting a new issue, or commenting on an existing one to claim it), you’ll next work on it and prepare to submit it to us as a pull request. A pull request says, “Hey, I did something useful for you, want to pull it in and merge it into your project?”
 
+A pull request is a chance for Quire’s core team to evaluate
+the proposed changes made and decide whether to:
 
------------
+- merge them in as is
+- merge them in with changes
+- reject them
 
-### Responsibilities (**Text below is placeholder text**)
+To avoid changes being rejected, we recommend you post about proposed changes on our issues board before you start work (which gives the core team and the community the chance to give feedback and raise any concerns ahead of time), and also to submit the pull request while work is still in progress.
 
-- Ensure cross-platform compatibility for every change that is accepted. Windows, Mac, Debian & Ubuntu Linux.
-- Ensure that code that goes into core meets all requirements in this checklist: https://gist.github.com/audreyr/4feef90445b9680475f2
-- Create issues for any major changes and enhancements that you wish to make. Discuss things transparently and get community feedback.
-- Don't add any classes to the codebase unless absolutely needed. Err on the side of using functions.
-- Keep feature versions as small as possible, preferably one new feature per version.
-- Be welcoming to newcomers and encourage diverse new contributors from all backgrounds.
+A pull request doesn’t have to represent finished work. We always recommend opening a pull request early on, so others can watch or give feedback on your progress. Just mark it as a “WIP” (Work in Progress) in the subject line. As you make new commits to that branch and push them to GitHub, they’ll automatically be added to the open pull request.
 
-### Your First Contribution (**Text below is placeholder text**)
+This is something like what the development process may look like for you:
 
-Unsure where to begin contributing to Quire? You can start by looking through these beginner and help-wanted issues:
+1. Fork the repository and clone it locally.
+  - Learn more about forks and clones in GitHub’s docs on [“Contributing and collaborating using GitHub Desktop”](https://docs.github.com/en/free-pro-team@latest/desktop/contributing-and-collaborating-using-github-desktop),
+  - Developers, please note that the `quire-starer-theme` is maintained as a submodule within `quire-starter` and they must be kept in synch. So, when submitting a pull request on the theme in particular, you may also need to submit a corresponding PR to the starter. Please make a note of this in the comments when submitting.
+2. Create a branch and make your changes.
+  - Contribute in the style of the project to the best of your abilities. We’re going to be writing Quire’s Style Guides to help with this, but in the meantime, please try to follow the patterns you see in the existing pages, for instance in naming classes, structuring page templates, and commenting your code for technical contributions, or in heading structure, tone, and tense for documentation contributions.
+  - Test your changes by running `quire preview`. Depending on the changes you’ve made you may also need to run `quire pdf` and `quire epub` to confirm things worked there as well. You may need to check various mobile views as well, which you can do using responsive design mode in your browser. In general, your goal with testing is to make sure your changes don’t break Quire’s existing styles or functionality. Of course, the project’s core team will be doing this too and can help guide you if something’s not working as expected.
+3. Submit a pull request through GitHub.
+  - If this is your first time putting in a pull request on a project like this, we recommend the [*First Contributions* command line](https://github.com/firstcontributions/first-contributions), or [GitHub Desktop]((https://github.com/firstcontributions/first-contributions/blob/master/gui-tool-tutorials/github-desktop-tutorial.md) tutorial. Or, Kent C. Dodds' video series [“How to Contribute to an Open Source Project on GitHub”](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+  - Reference any relevant issues or supporting documentation in your pull request description (for example, “Closes #203.”)
+  - Explain what the changes do, and what your approach was. If there were alternate ways of doing it, mention them and tell us why you didn’t choose them.
+  - If this is a Work in Progress pull request, comment on where you are and what your next steps are.
+  - Include screenshots of the before and after if your changes include differences in HTML/CSS. Drag and drop the images into the body of your pull request as needed.
+4. Respond as needed to the review of your work by Quire’s core team.
+  - Answer questions in the pull request comments.
+  - Make changes and new commits if needed, or suggest alternate solutions if you have them.
+5. See your work merged in to Quire! 🎉
 
-Beginner issues - issues which should only require a few lines of code, and a test or two.
+Learn more in the *Open Source Guide*’s [“How to Contribute to Open Source”](https://opensource.guide/how-to-contribute/).
 
-Help wanted issues - issues which should be a bit more involved than beginner issues.
+---
 
-Both issue lists are sorted by total number of comments. While not perfect, number of comments is a reasonable proxy for impact a given change will have.
-
-(Bonus points: Add a link to a resource for people who have never contributed to open source before.)
-
-Here are a couple of friendly tutorials you can include: http://makeapullrequest.com/ and http://www.firsttimersonly.com/
-
-Working on your first Pull Request? You can learn how from this free series, How to Contribute to an Open Source Project on GitHub.
-
-At this point, you're ready to make your changes! Feel free to ask for help; everyone is a beginner at first 😸
-
-If a maintainer asks you to "rebase" your PR, they're saying that a lot of code has changed, and that you need to update your branch so it's easier to merge.
-
+**At this point, you're ready to contribute! Feel free to [ask for help](mailto:quire@getty.edu), remember [everyone’s a beginner at first](https://firstpr.me/). And thank you again for your interest in making Quire a better tool for all!** 🦄

--- a/content/about/who-we-are.md
+++ b/content/about/who-we-are.md
@@ -1,0 +1,1 @@
+[@mphstudios](https://github.com/mphstudios)

--- a/content/community/forum.md
+++ b/content/community/forum.md
@@ -34,4 +34,4 @@ Examples of topics you will find covered in our forums include: **support, tips 
 
 - No attacks on other people.
 
-Please see our **[Quire Code of Conduct](https://quire/getty.edu/community/code-of-conduct)** for more information regarding appropriate behavior, as well as our anti-harassment policy.
+Please see our **[Quire Code of Conduct](https://github.com/gettypubs/quire/blob/master/CODE_OF_CONDUCT.md)** for more information regarding appropriate behavior, as well as our anti-harassment policy.

--- a/content/community/join-us.md
+++ b/content/community/join-us.md
@@ -92,7 +92,7 @@ We love celebrating Quire accomplishments. Send us your finished Quire publicati
 
 As an open-source community, all members have an opportunity to help mold Quire into a digital publishing solution that meets a diverse set of needs. This is your opportunity to contribute to the code and directly impact the development of the tool.
 
-Before getting started, we kindly request that you review our **[Contributor Guidelines](https://github.com/gettypubs/quire/blob/master/CONTRIBUTE.md)** for information on best practices, guidelines, and recommendations for contributing.
+Before getting started, we kindly request that you review our **[Contributor Guidelines](https://github.com/gettypubs/quire/blob/master/CONTRIBUTING.md)** for information on best practices, guidelines, and recommendations for contributing.
 
 <div class="action-button">
 
@@ -133,7 +133,7 @@ The [Quire Documentation](/documentation/) is a work in progress and we value yo
 
 <div class="action-button">
 
-[Read Our Contributor Guidelines](https://github.com/gettypubs/quire/blob/master/CONTRIBUTE.md)
+[Read Our Contributor Guidelines](https://github.com/gettypubs/quire/blob/master/CONTRIBUTING.md)
 
 </div>
 

--- a/content/community/join-us.md
+++ b/content/community/join-us.md
@@ -92,7 +92,7 @@ We love celebrating Quire accomplishments. Send us your finished Quire publicati
 
 As an open-source community, all members have an opportunity to help mold Quire into a digital publishing solution that meets a diverse set of needs. This is your opportunity to contribute to the code and directly impact the development of the tool.
 
-Before getting started, we kindly request that you review our **[Contributor Guidelines](/community/contributor-guidelines/)** for information on best practices, guidelines, and recommendations for contributing.
+Before getting started, we kindly request that you review our **[Contributor Guidelines](https://github.com/gettypubs/quire/blob/master/CONTRIBUTE.md)** for information on best practices, guidelines, and recommendations for contributing.
 
 <div class="action-button">
 
@@ -133,7 +133,7 @@ The [Quire Documentation](/documentation/) is a work in progress and we value yo
 
 <div class="action-button">
 
-[Read Our Contributor Guidelines](/community/contributor-guidelines/)
+[Read Our Contributor Guidelines](https://github.com/gettypubs/quire/blob/master/CONTRIBUTE.md)
 
 </div>
 

--- a/data/publication.yml
+++ b/data/publication.yml
@@ -86,6 +86,12 @@ resource_link:
     name: GitHub
     url: https://github.com/gettypubs/quire/
   - type: footer-link
+    name: Contributing
+    url: https://github.com/gettypubs/quire/blob/master/CONTRIBUTING.md
+  - type: footer-link
+    name: Code of Conduct
+    url: https://github.com/gettypubs/quire/blob/master/CODE_OF_CONDUCT.md
+  - type: footer-link
     name: About
     link_relation: about
     url: /about/quire/


### PR DESCRIPTION
This closes #237 and #236.

I've moved both of these files out of the About section and into the root level of the repository as CONTRIBUTING.md and CODE_OF_CONDUCT.md following some [GitHub standards and guidelines](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/setting-up-your-project-for-healthy-contributions). This will help them be surfaced in GitHub, but it means when we want to link to them from the Quire website, we have to link to the GitHub hosted version. For example at https://github.com/gettypubs/quire/blob/master/CONTRIBUTING.md. I've updated the site links accordingly, but note that they won't work until we push all the changes to the master branch.

I did very little to the Code of Conduct, but added a lot to the Contributor Guidelines and got rid of all the placeholder material. In writing there were three additional things I think it would be good for us to create and share:

- Quire Documentation Style Guide
- Quire Technical Style Guide
- A video or article tutorial on Making Your First Contribution

I know we've got a documentation style guide started, let's finalize where we're going to host it and talk about the other two things as well.


