### PR TITLE
Forum offsite link

### DIFF
--- a/content/access.md
+++ b/content/access.md
@@ -3,6 +3,5 @@ title: Get Access
 type: page
 weight: 7000
 external_url: https://forms.gle/m1fgZu5BHKhddMrW7
+search: false
 ---
-
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSckvPWWyyfZJko6JTqf3slcXCV8vcCgQjAzoW4MfHEt9hDuxQ/viewform?embedded=true" width="640" height="1896" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>

--- a/content/community/forum.md
+++ b/content/community/forum.md
@@ -4,6 +4,7 @@ weight: 2200
 type: essay
 abstract: "Connect with Quire users to answer questions and share ideas"
 external_url: https://github.com/gettypubs/quire/discussions
+search: false
 ---
 
 Welcome to the Quire forum! Here you will find community-based support to help you navigate the ins and outs of Quire. We encourage you to ask and answer questions, share ideas, raise issues, collaborate, and assist your fellow community members.

--- a/content/community/forum.md
+++ b/content/community/forum.md
@@ -3,6 +3,7 @@ title: Forum
 weight: 2200
 type: essay
 abstract: "Connect with Quire users to answer questions and share ideas"
+external_url: https://github.com/gettypubs/quire/discussions
 ---
 
 Welcome to the Quire forum! Here you will find community-based support to help you navigate the ins and outs of Quire. We encourage you to ask and answer questions, share ideas, raise issues, collaborate, and assist your fellow community members.

--- a/layouts/partials/contents-list.html
+++ b/layouts/partials/contents-list.html
@@ -153,7 +153,7 @@
 {{ $.Page.Scratch.Set "imagedir" "" }}
 {{- end -}}
   {{- if in .class "grid" -}}
-    <a {{ if .Params.external_url }}href="{{ .Params.external_url }}" target="_blank"{{ else }}href="{{ .Page.Permalink | relURL }}"{{ end }}{{- if lt .Page.Weight .pageOne }} class="frontmatter-page"{{ end }}><div class="card {{ if or .Page.Params.image .Page.Params.object }}image{{ else }}no-image{{ end }}{{ if and (ne .Page.Section "") (eq .Page.Slug ".") }} slug-page{{ end }}">
+    <a {{ if .Page.Params.external_url }}href="{{ .Page.Params.external_url }}" target="_blank"{{ else }}href="{{ .Page.Permalink | relURL }}"{{ end }}{{- if lt .Page.Weight .pageOne }} class="frontmatter-page"{{ end }}><div class="card {{ if or .Page.Params.image .Page.Params.object }}image{{ else }}no-image{{ end }}{{ if and (ne .Page.Section "") (eq .Page.Slug ".") }} slug-page{{ end }}">
       {{ if .Page.Params.image }}
         {{ $imgPath := printf "%s/%s" ($.Page.Scratch.Get "imageDir") .Page.Params.image }}
         <div class="card-image">
@@ -190,14 +190,14 @@
       {{- end -}}
       <div class="card-content">
         <div class="title">
-        {{- with .Page.Params.label }}{{ . }}{{ $.Site.Params.pageLabelDivider }}{{ end }}{{ if and .Page.Params.short_title (in .class "brief")}}{{ .Page.Params.short_title | markdownify }}{{ else if in .class "brief" }}{{ .Page.Title | markdownify }}{{ else }}{{ partial "page-title.html" . | markdownify }}{{ if .Page.Params.contributor }}<span class="contributor"> — {{ partial "contributor-list.html" (dict "range" .Page.Params.contributor "contributorType" "all" "listType" "string" "Site" .Site) }}</span>{{- end -}}{{- end -}}<span class="arrow remove-from-epub">&nbsp;{{- partial "icon.html" (dict "type" "arrow-forward" "description" "") -}}</span></div>
+        {{- with .Page.Params.label }}{{ . }}{{ $.Site.Params.pageLabelDivider }}{{ end }}{{ if and .Page.Params.short_title (in .class "brief")}}{{ .Page.Params.short_title | markdownify }}{{ else if in .class "brief" }}{{ .Page.Title | markdownify }}{{ else }}{{ partial "page-title.html" . | markdownify }}{{ if .Page.Params.contributor }}<span class="contributor"> — {{ partial "contributor-list.html" (dict "range" .Page.Params.contributor "contributorType" "all" "listType" "string" "Site" .Site) }}</span>{{- end -}}{{- end -}}<span class="arrow{{ if .Page.Params.external_url }} arrow-offsite{{ end }} remove-from-epub">&nbsp;{{- partial "icon.html" (dict "type" "arrow-forward" "description" "") -}}</span></div>
         {{ with .Page.Params.abstract }}<div class="abstract">{{ . | markdownify | truncate 80 }}</div>{{ end }}
       </div>
     </div></a>
 
   {{- else -}}
 
-    <div class="title"><a {{ if .Params.external_url }}href="{{ .Params.external_url }}" target="_blank"{{ else }}href="{{ .Page.Permalink | relURL }}"{{ end }}{{- if lt .Page.Weight .pageOne }} class="frontmatter-page"{{ end }}>{{ with .Page.Params.label }}{{ . }}{{ $.Site.Params.pageLabelDivider }}{{ end }}{{ if and .Page.Params.short_title (in .class "brief")}}{{ .Page.Params.short_title | markdownify }}{{ else if in .class "brief" }}{{ .Page.Title | markdownify }}{{ else }}{{ partial "page-title.html" . | markdownify }}{{ if .Page.Params.contributor }}<span class="contributor"> — {{ partial "contributor-list.html" (dict "range" .Page.Params.contributor "contributorType" "all" "listType" "string" "Site" .Site) }}</span>{{- end -}}{{- end -}}<span class="arrow remove-from-epub">&nbsp;{{- partial "icon.html" (dict "type" "arrow-forward" "description" "") -}}</span></a></div>
+    <div class="title"><a {{ if .Page.Params.external_url }}href="{{ .Page.Params.external_url }}" target="_blank"{{ else }}href="{{ .Page.Permalink | relURL }}"{{ end }}{{- if lt .Page.Weight .pageOne }} class="frontmatter-page"{{ end }}>{{ with .Page.Params.label }}{{ . }}{{ $.Site.Params.pageLabelDivider }}{{ end }}{{ if and .Page.Params.short_title (in .class "brief")}}{{ .Page.Params.short_title | markdownify }}{{ else if in .class "brief" }}{{ .Page.Title | markdownify }}{{ else }}{{ partial "page-title.html" . | markdownify }}{{ if .Page.Params.contributor }}<span class="contributor"> — {{ partial "contributor-list.html" (dict "range" .Page.Params.contributor "contributorType" "all" "listType" "string" "Site" .Site) }}</span>{{- end -}}{{- end -}}<span class="arrow remove-from-epub">&nbsp;{{- partial "icon.html" (dict "type" "arrow-forward" "description" "") -}}</span></a></div>
 
     {{ if and (in .class "abstract") (ne .Page.Params.abstract "") }}
       <div class="abstract-text">

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -515,6 +515,10 @@ a.quire-navbar-controls__site-logo img {
   width: 1em;
   margin-left: .25em;
 }
+/* Use dark gray arrow in page items */
+.section-item ul .page-item a[target=_blank]::after {
+  content: url('../img/icons/right-up-arrow--dark-gray.svg');
+}
 /* Make these links the accent color */
 .quire-navbar a[target=_blank],
 .quire-menu__list > ul > .page-item a[target=_blank] {
@@ -767,6 +771,10 @@ dt code {
 /* More space at bottom of page */
 .quire-page__content .container .content {
   padding-bottom: 8rem;
+}
+/* Tilt arrows when link if external */
+.quire-contents-list .arrow-offsite svg {
+  transform: rotate(-45deg);
 }
 
 /* GRID LAYOUT -- JOIN US PAGE


### PR DESCRIPTION
This makes the Forum link to the GitHub Discussions page rather than to the Markdown page on the Quire site. I also added `search: false` to the two externally linked pages to make sure Quire's search function doesn't try to send people to the internal version of those pages.